### PR TITLE
refactor: update event interfaces and improve type handling

### DIFF
--- a/packages/core/src/events/m.room.guest_access.ts
+++ b/packages/core/src/events/m.room.guest_access.ts
@@ -7,7 +7,7 @@ declare module "./eventBase" {
 	}
 }
 
-interface RoomGuestAccessEvent extends EventBase {
+export interface RoomGuestAccessEvent extends EventBase {
 	content: {
 		guest_access: "can_join" | "forbidden";
 	};
@@ -43,6 +43,5 @@ export const roomGuestAccessEvent = ({
 	});
 };
 
-export const createRoomGuestAccessEvent = createEventWithId(
-	roomGuestAccessEvent as any,
-);
+export const createRoomGuestAccessEvent =
+	createEventWithId(roomGuestAccessEvent);

--- a/packages/core/src/events/m.room.history_visibility.ts
+++ b/packages/core/src/events/m.room.history_visibility.ts
@@ -7,7 +7,7 @@ declare module "./eventBase" {
 	}
 }
 
-interface RoomHistoryVisibilityEvent extends EventBase {
+export interface RoomHistoryVisibilityEvent extends EventBase {
 	content: {
 		history_visibility: "shared" | "invited" | "joined";
 	};
@@ -46,5 +46,5 @@ export const roomHistoryVisibilityEvent = ({
 };
 
 export const createRoomHistoryVisibilityEvent = createEventWithId(
-	roomHistoryVisibilityEvent as any,
+	roomHistoryVisibilityEvent,
 );

--- a/packages/core/src/events/m.room.join_rules.ts
+++ b/packages/core/src/events/m.room.join_rules.ts
@@ -52,9 +52,7 @@ export const roomJoinRulesEvent = ({
 	});
 };
 
-export const createRoomJoinRulesEvent = createEventWithId(
-	roomJoinRulesEvent as any,
-);
+export const createRoomJoinRulesEvent = createEventWithId(roomJoinRulesEvent);
 
 export const isRoomJoinRulesEvent = (
 	event: EventBase,

--- a/packages/core/src/events/m.room.member.ts
+++ b/packages/core/src/events/m.room.member.ts
@@ -122,6 +122,4 @@ export const roomMemberEvent = ({
 	});
 };
 
-export const createRoomMemberEvent = createEventWithId(
-	roomMemberEvent as any,
-);
+export const createRoomMemberEvent = createEventWithId(roomMemberEvent);

--- a/packages/core/src/events/m.room.power_levels.ts
+++ b/packages/core/src/events/m.room.power_levels.ts
@@ -94,9 +94,8 @@ export const roomPowerLevelsEvent = ({
 	});
 };
 
-export const createRoomPowerLevelsEvent = createEventWithId(
-	roomPowerLevelsEvent as any,
-);
+export const createRoomPowerLevelsEvent =
+	createEventWithId(roomPowerLevelsEvent);
 
 export const isRoomPowerLevelsEvent = (
 	event: EventBase,

--- a/packages/core/src/events/utils/createSignedEvent.ts
+++ b/packages/core/src/events/utils/createSignedEvent.ts
@@ -6,22 +6,24 @@ export const createSignedEvent = (
 	signature: SigningKey,
 	signingName: string,
 ) => {
-	return <F extends (...args: unknown[]) => unknown>(fn: F) => {
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	return <F extends (...args: any[]) => any>(fn: F) => {
 		return async (...args: Parameters<F>): Promise<ReturnType<F>> => {
-			return signEvent(await fn(...args) as any, signature, signingName) as Promise<
+			return signEvent(await fn(...args), signature, signingName) as Promise<
 				ReturnType<F>
 			>;
 		};
 	};
 };
 
-export const createEventWithId = <F extends (...args: unknown[]) => unknown>(fn: F) => {
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export const createEventWithId = <F extends (...args: any[]) => any>(fn: F) => {
 	return <S extends ReturnType<typeof createSignedEvent>>(sign: S) => {
 		return async (
 			...args: Parameters<F>
 		): Promise<{ event: ReturnType<F>; _id: string }> => {
 			const event = await sign(fn)(...args);
-			const id = generateId(event as any);
+			const id = generateId(event);
 			return {
 				event,
 				_id: id,

--- a/packages/homeserver/src/procedures/createRoom.ts
+++ b/packages/homeserver/src/procedures/createRoom.ts
@@ -1,11 +1,34 @@
 import type { EventBase } from "@hs/core/src/events/eventBase";
-import { createRoomCreateEvent } from "@hs/core/src/events/m.room.create";
-import { createRoomGuestAccessEvent } from "@hs/core/src/events/m.room.guest_access";
-import { createRoomHistoryVisibilityEvent } from "@hs/core/src/events/m.room.history_visibility";
-import { createRoomJoinRulesEvent } from "@hs/core/src/events/m.room.join_rules";
-import { createRoomMemberEvent } from "@hs/core/src/events/m.room.member";
-import { createRoomPowerLevelsEvent } from "@hs/core/src/events/m.room.power_levels";
+import {
+	createRoomCreateEvent,
+	type RoomCreateEvent,
+} from "@hs/core/src/events/m.room.create";
+import {
+	createRoomGuestAccessEvent,
+	type RoomGuestAccessEvent,
+} from "@hs/core/src/events/m.room.guest_access";
+import {
+	createRoomHistoryVisibilityEvent,
+	type RoomHistoryVisibilityEvent,
+} from "@hs/core/src/events/m.room.history_visibility";
+import {
+	createRoomJoinRulesEvent,
+	type RoomJoinRulesEvent,
+} from "@hs/core/src/events/m.room.join_rules";
+import {
+	createRoomMemberEvent,
+	type RoomMemberEvent,
+} from "@hs/core/src/events/m.room.member";
+import {
+	createRoomPowerLevelsEvent,
+	type RoomPowerLevelsEvent,
+} from "@hs/core/src/events/m.room.power_levels";
 import type { createSignedEvent } from "@hs/core/src/events/utils/createSignedEvent";
+
+type IdAndEvent<T extends EventBase> = {
+	event: T;
+	_id: string;
+};
 
 export const createRoom = async (
 	users: [sender: string, ...username: string[]],
@@ -13,10 +36,14 @@ export const createRoom = async (
 	roomId: string,
 ): Promise<{
 	roomId: string;
-	events: {
-		event: EventBase;
-		_id: string;
-	}[];
+	events: [
+		createEvent: IdAndEvent<RoomCreateEvent>,
+		memberEvent: IdAndEvent<RoomMemberEvent>,
+		powerLevelsEvent: IdAndEvent<RoomPowerLevelsEvent>,
+		joinRulesEvent: IdAndEvent<RoomJoinRulesEvent>,
+		historyVisibilityEvent: IdAndEvent<RoomHistoryVisibilityEvent>,
+		guestAccessEvent: IdAndEvent<RoomGuestAccessEvent>,
+	];
 }> => {
 	// Create
 
@@ -109,17 +136,15 @@ export const createRoom = async (
 		depth: 6,
 	});
 
-	const events = [
-		createEvent,
-		memberEvent,
-		powerLevelsEvent,
-		joinRulesEvent,
-		historyVisibilityEvent,
-		guestAccessEvent,
-	];
-
 	return {
 		roomId,
-		events: events as any,
+		events: [
+			createEvent,
+			memberEvent,
+			powerLevelsEvent,
+			joinRulesEvent,
+			historyVisibilityEvent,
+			guestAccessEvent,
+		],
 	};
 };

--- a/packages/homeserver/src/services/room.service.ts
+++ b/packages/homeserver/src/services/room.service.ts
@@ -25,7 +25,7 @@ export class RoomService {
 	constructor(
 		private readonly roomRepository: RoomRepository,
 		private readonly eventService: EventService,
-		private readonly configService: ConfigService
+		private readonly configService: ConfigService,
 	) {}
 
 	async upsertRoom(roomId: string, state: ModelEventBase[]) {
@@ -65,7 +65,10 @@ export class RoomService {
 	/**
 	 * Create a new room with the given sender and username
 	 */
-	async createRoom(username: string, sender: string): Promise<{
+	async createRoom(
+		username: string,
+		sender: string,
+	): Promise<{
 		roomId: string;
 		events: EventBase[];
 	}> {
@@ -80,21 +83,27 @@ export class RoomService {
 		const roomId = `!${createMediaId(18)}:${config.name}`;
 		const result = await createRoom(
 			[sender, username],
-			createSignedEvent(Array.isArray(signingKey) ? signingKey[0] : signingKey, config.name),
-			roomId
+			createSignedEvent(
+				Array.isArray(signingKey) ? signingKey[0] : signingKey,
+				config.name,
+			),
+			roomId,
 		);
 
-		if (result.events.length === 0) {
-			throw new HttpException("Error creating room", HttpStatus.INTERNAL_SERVER_ERROR);
+		if (result.events.filter(Boolean).length === 0) {
+			throw new HttpException(
+				"Error creating room",
+				HttpStatus.INTERNAL_SERVER_ERROR,
+			);
 		}
 
 		for (const eventObj of result.events) {
-			await this.eventService.insertEvent(eventObj.event as any, eventObj._id);
+			await this.eventService.insertEvent(eventObj.event, eventObj._id);
 		}
 
 		return {
 			roomId: result.roomId,
-			events: result.events.map(e => e.event)
+			events: result.events.map((e) => e.event),
 		};
 	}
 }


### PR DESCRIPTION
- Changed event interfaces to be exported in `m.room.guest_access`, `m.room.history_visibility`, `m.room.join_rules`, `m.room.member`, and `m.room.power_levels`.
- Simplified the creation of events by removing unnecessary type assertions in `createEventWithId`.
- Enhanced type safety in `createRoom` by defining a new `IdAndEvent` type for event objects.