### PR TITLE
feat: send message reactions

### DIFF
--- a/packages/core/src/events/eventBase.ts
+++ b/packages/core/src/events/eventBase.ts
@@ -9,6 +9,7 @@ export type EventBase = {
 		| "m.room.aliases"
 		| "m.room.history_visibility"
 		| "m.room.redaction"
+		| "m.reaction"
 		| string;
 	room_id: string;
 	sender: string;

--- a/packages/core/src/events/m.reaction.spec.ts
+++ b/packages/core/src/events/m.reaction.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+
+import { generateId } from "../../../homeserver/src/authentication";
+import { generateKeyPairsFromString } from "../../../homeserver/src/keys";
+import { signEvent } from "../../../homeserver/src/signEvent";
+import { reactionEvent } from "./m.reaction";
+
+const finalEvent = {
+	auth_events: [
+		"$lBxmA2J-6fGfOjUZ6dPCanOdBdkawli08Jf1IuH8aso",
+		"$mxzNPfcqEDUUuWm7xs44NguWJ3A2nWu6UxXt4TlX-T8",
+		"$TK2UQZ-AEsSoIIRoTKYBTf9c1wW8X3AmjLhnuiSnDmY"
+	],
+	prev_events: ["$8ftnUd9WTPTQGbdPgfOPea8bOEQ21qPvbcGqeOApQxA"],
+	type: "m.reaction",
+	room_id: "!MZyyuzkUwHEaBBOXai:hs1",
+	sender: "@user:rc1",
+	depth: 4,
+	origin: "rc1",
+	origin_server_ts: 1747837631863,
+	content: {
+		"m.relates_to": {
+			rel_type: "m.annotation",
+			event_id: "$8ftnUd9WTPTQGbdPgfOPea8bOEQ21qPvbcGqeOApQxA",
+			key: ":+1:",
+		},
+	}
+};
+
+test("reactionEvent", async () => {
+	const signature = await generateKeyPairsFromString(
+		"ed25519 a_HDhg WntaJ4JP5WbZZjDShjeuwqCybQ5huaZAiowji7tnIEw",
+	);
+
+	const { state_key: reactionStateKey, ...reaction } = reactionEvent({
+		roomId: "!MZyyuzkUwHEaBBOXai:hs1",
+		sender: "@user:rc1",
+		auth_events: {
+			"m.room.create": "$lBxmA2J-6fGfOjUZ6dPCanOdBdkawli08Jf1IuH8aso",
+			"m.room.power_levels": "$mxzNPfcqEDUUuWm7xs44NguWJ3A2nWu6UxXt4TlX-T8",
+			"m.room.member": "$TK2UQZ-AEsSoIIRoTKYBTf9c1wW8X3AmjLhnuiSnDmY",
+		},
+		prev_events: ["$8ftnUd9WTPTQGbdPgfOPea8bOEQ21qPvbcGqeOApQxA"],
+		depth: 4,
+		content: {
+			"m.relates_to": {
+				rel_type: "m.annotation",
+				event_id: "$8ftnUd9WTPTQGbdPgfOPea8bOEQ21qPvbcGqeOApQxA",
+				key: ":+1:",
+			},
+		},
+		origin: "rc1",
+		ts: 1747837631863,
+	});
+	
+	const signedReaction = await signEvent(reaction, signature, "rc1");
+	const reactionEventId = generateId(signedReaction);
+	
+	expect(signedReaction).toMatchObject(finalEvent);
+	expect(reactionEventId).toBe(reactionEventId);
+}); 

--- a/packages/core/src/events/m.reaction.ts
+++ b/packages/core/src/events/m.reaction.ts
@@ -19,9 +19,9 @@ declare module "./eventBase" {
 }
 
 export type ReactionAuthEvents = {
-    "m.room.create": string;
-    "m.room.power_levels": string;
-    "m.room.member": string;
+    "m.room.create": string | undefined;
+    "m.room.power_levels": string | undefined;
+    "m.room.member": string | undefined;
 }
 
 export const isReactionEvent = (

--- a/packages/core/src/events/m.reaction.ts
+++ b/packages/core/src/events/m.reaction.ts
@@ -11,6 +11,9 @@ declare module "./eventBase" {
                     key: string;
                 };
             };
+            unsigned: {
+                age_ts: number;
+            };
         };
     }
 }
@@ -36,6 +39,9 @@ export interface ReactionEvent extends EventBase {
             key: string;
         };
     };
+    unsigned: {
+        age_ts: number;
+    };
 }
 
 const isTruthy = <T>(value: T | null | undefined | false | 0 | ''): value is T => {
@@ -51,6 +57,7 @@ export const reactionEvent = ({
     content,
     origin,
     ts = Date.now(),
+    unsigned,
 }: {
     roomId: string;
     sender: string;
@@ -66,6 +73,7 @@ export const reactionEvent = ({
     };
     origin?: string;
     ts?: number;
+    unsigned?: { age_ts?: number };
 }): ReactionEvent => {
     return createEventBase("m.reaction", {
         roomId,
@@ -81,7 +89,8 @@ export const reactionEvent = ({
         origin_server_ts: ts,
         ts,
         origin,
+        unsigned: { ...unsigned, age_ts: ts },
     });
 };
 
-export const createReactionEvent = createEventWithId(reactionEvent); 
+export const createReactionEvent = createEventWithId(reactionEvent);

--- a/packages/homeserver/src/controllers/internal/message.controller.ts
+++ b/packages/homeserver/src/controllers/internal/message.controller.ts
@@ -3,11 +3,12 @@ import type { RoomMessageEvent } from "@hs/core/src/events/m.room.message";
 import {
   Body,
   Controller,
-  Post
+  Post,
 } from "@nestjs/common";
 import { z } from "zod";
 import { MessageService } from "../../services/message.service";
 import type { SignedEvent } from "../../signEvent";
+import { ZodValidationPipe } from '../../validation/pipes/zod-validation.pipe';
 
 const SendMessageSchema = z.object({
   roomId: z.string(),
@@ -33,12 +34,12 @@ export class InternalMessageController {
 	constructor(private readonly messageService: MessageService) {}
 
 	@Post("messages")
-  async sendMessage(@Body() body: z.infer<typeof SendMessageSchema>): Promise<SendMessageResponseDto> {
+  async sendMessage(@Body(new ZodValidationPipe(SendMessageSchema)) body: z.infer<typeof SendMessageSchema>): Promise<SendMessageResponseDto> {
     return this.messageService.sendMessage(body.roomId, body.message, body.senderUserId, body.targetServer);
   }
 
   @Post("reactions")
-  async sendReaction(@Body() body: z.infer<typeof SendReactionSchema>): Promise<SendReactionResponseDto> {
+  async sendReaction(@Body(new ZodValidationPipe(SendReactionSchema)) body: z.infer<typeof SendReactionSchema>): Promise<SendReactionResponseDto> {
     return this.messageService.sendReaction(body.roomId, body.eventId, body.emoji, body.senderUserId, body.targetServer);
   }
 }

--- a/packages/homeserver/src/controllers/internal/message.controller.ts
+++ b/packages/homeserver/src/controllers/internal/message.controller.ts
@@ -1,9 +1,9 @@
 import type { ReactionEvent } from "@hs/core/src/events/m.reaction";
 import type { RoomMessageEvent } from "@hs/core/src/events/m.room.message";
 import {
-    Body,
-    Controller,
-    Post
+  Body,
+  Controller,
+  Post
 } from "@nestjs/common";
 import { z } from "zod";
 import { MessageService } from "../../services/message.service";

--- a/packages/homeserver/src/controllers/internal/message.controller.ts
+++ b/packages/homeserver/src/controllers/internal/message.controller.ts
@@ -1,8 +1,9 @@
+import type { ReactionEvent } from "@hs/core/src/events/m.reaction";
 import type { RoomMessageEvent } from "@hs/core/src/events/m.room.message";
 import {
-  Body,
-  Controller,
-  Post
+    Body,
+    Controller,
+    Post
 } from "@nestjs/common";
 import { z } from "zod";
 import { MessageService } from "../../services/message.service";
@@ -17,6 +18,16 @@ const SendMessageSchema = z.object({
 
 type SendMessageResponseDto = SignedEvent<RoomMessageEvent>;
 
+const SendReactionSchema = z.object({
+  roomId: z.string(),
+  targetServer: z.string(),
+  eventId: z.string(),
+  emoji: z.string(),
+  senderUserId: z.string(),
+});
+
+type SendReactionResponseDto = SignedEvent<ReactionEvent>;
+
 @Controller("internal")
 export class InternalMessageController {
 	constructor(private readonly messageService: MessageService) {}
@@ -24,5 +35,10 @@ export class InternalMessageController {
 	@Post("messages")
   async sendMessage(@Body() body: z.infer<typeof SendMessageSchema>): Promise<SendMessageResponseDto> {
     return this.messageService.sendMessage(body.roomId, body.message, body.senderUserId, body.targetServer);
+  }
+
+  @Post("reactions")
+  async sendReaction(@Body() body: z.infer<typeof SendReactionSchema>): Promise<SendReactionResponseDto> {
+    return this.messageService.sendReaction(body.roomId, body.eventId, body.emoji, body.senderUserId, body.targetServer);
   }
 }

--- a/packages/homeserver/src/services/event.service.ts
+++ b/packages/homeserver/src/services/event.service.ts
@@ -5,8 +5,8 @@ import { generateId } from "../authentication";
 import { MatrixError } from "../errors";
 import type { EventBase, EventStore } from "../models/event.model";
 import {
-    getPublicKeyFromRemoteServer,
-    makeGetPublicKeyFromServerProcedure,
+	getPublicKeyFromRemoteServer,
+	makeGetPublicKeyFromServerProcedure,
 } from "../procedures/getPublicKeyFromServer";
 import { StagingAreaQueue } from "../queues/staging-area.queue";
 import { EventRepository } from "../repositories/event.repository";

--- a/packages/homeserver/src/services/message.service.ts
+++ b/packages/homeserver/src/services/message.service.ts
@@ -104,7 +104,11 @@ export class MessageService {
             serverName
         );
 
+        console.log(signedEvent);
+
         await this.federationService.sendEvent(targetServer, signedEvent);
+        
+        this.logger.log(`Sent reaction ${emoji} to ${targetServer} for event ${eventId} - ${generateId(signedEvent)}`);
 
         return signedEvent;
     }

--- a/packages/homeserver/src/services/message.service.ts
+++ b/packages/homeserver/src/services/message.service.ts
@@ -1,12 +1,16 @@
+import { reactionEvent, type ReactionAuthEvents, type ReactionEvent } from "@hs/core/src/events/m.reaction";
 import { roomMessageEvent, type MessageAuthEvents, type RoomMessageEvent } from "@hs/core/src/events/m.room.message";
 import { FederationService } from "@hs/federation-sdk";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
+import { generateId } from "../authentication";
 import { signEvent, type SignedEvent } from "../signEvent";
 import { ConfigService } from "./config.service";
 import { EventService, EventType } from "./event.service";
 
 @Injectable()
 export class MessageService {
+    private readonly logger = new Logger(MessageService.name);
+
     constructor(
         private readonly eventService: EventService,
         private readonly configService: ConfigService,
@@ -54,6 +58,54 @@ export class MessageService {
 
 		await this.federationService.sendEvent(targetServer, signedEvent);
 
+        this.logger.log(`Sent message to ${targetServer} - ${generateId(signedEvent)}`);
+
 		return signedEvent;
+    }
+
+    async sendReaction(roomId: string, eventId: string, emoji: string, senderUserId: string, targetServer: string): Promise<SignedEvent<ReactionEvent>> {
+        const serverName = this.configService.getServerConfig().name;
+        const signingKey = await this.configService.getSigningKey();
+
+        const latestEventDoc = await this.eventService.getLastEventForRoom(roomId);
+        const prevEvents = latestEventDoc ? [latestEventDoc._id] : [];
+        
+        const authEvents = await this.eventService.getAuthEventsIds({ roomId, eventType: EventType.REACTION, senderId: senderUserId });
+        
+        const currentDepth = latestEventDoc?.event?.depth ?? 0;
+        const newDepth = currentDepth + 1;
+
+        const authEventsMap: ReactionAuthEvents = {
+            "m.room.create": authEvents.find(event => event.type === EventType.CREATE)?._id || "",
+            "m.room.power_levels": authEvents.find(event => event.type === EventType.POWER_LEVELS)?._id || "",
+            "m.room.member": authEvents.find(event => event.type === EventType.MEMBER)?._id || "",
+        };
+        
+        const { state_key, ...eventForSigning } = reactionEvent({
+            roomId,
+            sender: senderUserId,
+            auth_events: authEventsMap,
+            prev_events: prevEvents,
+            depth: newDepth,
+            content: {
+                "m.relates_to": {
+                    rel_type: "m.annotation",
+                    event_id: eventId,
+                    key: emoji
+                }
+            },
+            origin: serverName,
+            ts: Date.now(),
+        });
+
+        const signedEvent = await signEvent(
+            eventForSigning,
+            Array.isArray(signingKey) ? signingKey[0] : signingKey, 
+            serverName
+        );
+
+        await this.federationService.sendEvent(targetServer, signedEvent);
+
+        return signedEvent;
     }
 }

--- a/packages/homeserver/src/utils/event-schemas.ts
+++ b/packages/homeserver/src/utils/event-schemas.ts
@@ -47,6 +47,17 @@ const messageEventSchema = baseEventSchema.extend({
   }).and(z.record(z.any())),
 });
 
+const reactionEventSchema = baseEventSchema.extend({
+  type: z.literal('m.reaction'),
+  content: z.object({
+    'm.relates_to': z.object({
+      rel_type: z.literal('m.annotation'),
+      event_id: z.string(),
+      key: z.string(),
+    }),
+  }).and(z.record(z.any())),
+});
+
 const powerLevelsEventSchema = baseEventSchema.extend({
   type: z.literal('m.room.power_levels'),
   state_key: z.literal(''),
@@ -77,6 +88,7 @@ const roomV10Schemas = {
   'm.room.message': messageEventSchema,
   'm.room.power_levels': powerLevelsEventSchema,
   'm.room.join_rules': joinRulesEventSchema,
+  'm.reaction': reactionEventSchema,
   'default': baseEventSchema,
 };
 


### PR DESCRIPTION
As per [FDR-25](https://rocketchat.atlassian.net/browse/FDR-25) this PR adds send message reactions support via internal endpoint called `POST /internal/reactions`.

[FDR-25]: https://rocketchat.atlassian.net/browse/FDR-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ