### PR TITLE
feat: update user power levels

### DIFF
--- a/packages/core/src/events/m.room.member.spec.ts
+++ b/packages/core/src/events/m.room.member.spec.ts
@@ -69,3 +69,217 @@ test("roomMemberEvent", async () => {
 
 	expect(memberEventId).toBe(finalEventId);
 });
+
+test("roomMemberEvent - leave", async () => {
+	const signature = await generateKeyPairsFromString(
+		"ed25519 a_HDhg WntaJ4JP5WbZZjDShjeuwqCybQ5huaZAiowji7tnIEw",
+	);
+	const serverName = "hs1";
+	const roomId = "!leaveRoomTest:hs1";
+	const userId = "@user_to_leave:hs1";
+	const ts = Date.now();
+
+	const createEventPayload = roomCreateEvent({
+		roomId,
+		sender: userId,
+		ts: ts - 1000,
+	});
+	const signedCreateEvent = await signEvent(createEventPayload, signature, serverName);
+	const createEventId = generateId(signedCreateEvent);
+
+	// A user usually joins before they can leave
+	const joinMemberEventPayload = roomMemberEvent({
+		membership: "join",
+		roomId,
+		sender: userId,
+		state_key: userId,
+		content: { displayname: "User To Leave" },
+		depth: 2, // Assuming create is depth 1
+		auth_events: { "m.room.create": createEventId },
+		prev_events: [createEventId],
+		ts: ts - 500,
+		origin: serverName,
+	});
+	const signedJoinEvent = await signEvent(joinMemberEventPayload, signature, serverName);
+	const joinEventId = generateId(signedJoinEvent);
+
+	// Now, the leave event
+	const leaveMemberEventPayload = roomMemberEvent({
+		membership: "leave",
+		roomId,
+		sender: userId,
+		state_key: userId, // User leaving themselves
+		depth: 3, // After create and join
+		auth_events: {
+			"m.room.create": createEventId,
+			[`m.room.member:${userId}`]: joinEventId, 
+		},
+		prev_events: [joinEventId],
+		ts,
+		origin: serverName,
+		content: {
+			membership: "leave",
+		},
+	});
+
+	const signedLeaveEvent = await signEvent(leaveMemberEventPayload, signature, serverName);
+	const leaveEventId = generateId(signedLeaveEvent);
+
+	expect(signedLeaveEvent.type).toBe("m.room.member");
+	expect(signedLeaveEvent.room_id).toBe(roomId);
+	expect(signedLeaveEvent.sender).toBe(userId);
+	expect(signedLeaveEvent.state_key).toBe(userId);
+	expect(signedLeaveEvent.content.membership).toBe("leave");
+	expect(signedLeaveEvent.origin).toBe(serverName);
+	expect(signedLeaveEvent.origin_server_ts).toBe(ts);
+	expect(signedLeaveEvent.prev_events).toEqual([joinEventId]);
+	expect(signedLeaveEvent.auth_events).toContain(createEventId);
+	expect(signedLeaveEvent.auth_events).toContain(joinEventId);
+	expect(leaveEventId).toBeDefined();
+	expect(signedLeaveEvent.signatures[serverName][`${signature.algorithm}:${signature.version}`]).toBeString();
+	expect(Object.keys(signedLeaveEvent.content).length).toBe(1);
+});
+
+test("roomMemberEvent - kick", async () => {
+	const kickerSignature = await generateKeyPairsFromString(
+		"ed25519 kicker_key WntaJ4JP5WbZZjDShjeuwqCybQ5huaZAiowji7tnIEw",
+	);
+	const userToKickSignature = await generateKeyPairsFromString(
+		"ed25519 kicked_key WntaJ4JP5WbZZjDShjeuwqCybQ5huaZAiowji7tnIEw",
+	);
+	const serverName = "hs1";
+	const roomId = "!kickRoomTest:hs1";
+	const kickerId = "@kicker:hs1";
+	const userToKickId = "@user_to_kick:hs1";
+	const kickReason = "Not a team player";
+	let ts = Date.now();
+
+	// 1. Create Event (sent by kicker)
+	const createEventPayload = roomCreateEvent({
+		roomId,
+		sender: kickerId,
+		ts: ts - 4000,
+	});
+	const signedCreateEvent = await signEvent(createEventPayload, kickerSignature, serverName);
+	const createEventId = generateId(signedCreateEvent);
+	let lastEventId = createEventId;
+	let currentDepth = 1;
+
+	// 2. Power Levels Event (sent by kicker)
+	// Kicker has power 100, can kick at 50. UserToKick has power 0.
+	const powerLevelsEventPayload = {
+		type: "m.room.power_levels",
+		room_id: roomId,
+		sender: kickerId,
+		state_key: "",
+		content: {
+			users: {
+				[kickerId]: 100,
+				[userToKickId]: 0,
+			},
+			users_default: 0,
+			events: {
+				"m.room.name": 50,
+				"m.room.power_levels": 100,
+			},
+			events_default: 50,
+			state_default: 50,
+			kick: 50, // Kicker (100) can kick users if kick level is 50
+			ban: 50,
+			redact: 50,
+		},
+		depth: ++currentDepth,
+		auth_events: [createEventId],
+		prev_events: [lastEventId],
+		origin: serverName,
+		origin_server_ts: ts - 3000,
+	};
+	const signedPowerLevelsEvent = await signEvent(powerLevelsEventPayload, kickerSignature, serverName);
+	const powerLevelsEventId = generateId(signedPowerLevelsEvent);
+	lastEventId = powerLevelsEventId;
+
+	// 3. Kicker Joins (sent by kicker)
+	const kickerJoinEventPayload = roomMemberEvent({
+		membership: "join",
+		roomId,
+		sender: kickerId,
+		state_key: kickerId,
+		content: { displayname: "Kicker User" },
+		depth: ++currentDepth,
+		auth_events: { 
+			"m.room.create": createEventId,
+			"m.room.power_levels": powerLevelsEventId,
+		 },
+		prev_events: [lastEventId],
+		ts: ts - 2000,
+		origin: serverName,
+	});
+	const signedKickerJoinEvent = await signEvent(kickerJoinEventPayload, kickerSignature, serverName);
+	const kickerJoinEventId = generateId(signedKickerJoinEvent);
+	lastEventId = kickerJoinEventId;
+
+	// 4. UserToKick Joins (sent by userToKick)
+	const userToKickJoinEventPayload = roomMemberEvent({
+		membership: "join",
+		roomId,
+		sender: userToKickId,
+		state_key: userToKickId,
+		content: { displayname: "User To Be Kicked" },
+		depth: ++currentDepth,
+		auth_events: { 
+			"m.room.create": createEventId,
+			"m.room.power_levels": powerLevelsEventId,
+		 },
+		prev_events: [lastEventId],
+		ts: ts - 1000,
+		origin: serverName,
+	});
+	const signedUserToKickJoinEvent = await signEvent(userToKickJoinEventPayload, userToKickSignature, serverName);
+	const userToKickJoinEventId = generateId(signedUserToKickJoinEvent);
+	lastEventId = userToKickJoinEventId;
+
+	// 5. Kick Event (sent by kicker, targets userToKick)
+	ts = Date.now();
+	const kickMemberEventPayload = roomMemberEvent({
+		membership: "leave",
+		roomId,
+		sender: kickerId,
+		state_key: userToKickId,
+		depth: ++currentDepth,
+		auth_events: {
+			"m.room.create": createEventId,
+			"m.room.power_levels": powerLevelsEventId,
+			[`m.room.member:${userToKickId}`]: kickerJoinEventId, 
+		},
+		prev_events: [lastEventId],
+		ts,
+		origin: serverName,
+		content: {
+			membership: "leave",
+			reason: kickReason,
+		},
+	});
+
+	const signedKickEvent = await signEvent(kickMemberEventPayload, kickerSignature, serverName);
+	const kickEventId = generateId(signedKickEvent);
+
+	// Assertions
+	expect(signedKickEvent.type).toBe("m.room.member");
+	expect(signedKickEvent.room_id).toBe(roomId);
+	expect(signedKickEvent.sender).toBe(kickerId);
+	expect(signedKickEvent.state_key).toBe(userToKickId);
+	expect(signedKickEvent.content.membership).toBe("leave");
+	expect(signedKickEvent.content.reason).toBe(kickReason);
+	expect(signedKickEvent.origin).toBe(serverName);
+	expect(signedKickEvent.origin_server_ts).toBe(ts);
+	expect(signedKickEvent.prev_events).toEqual([userToKickJoinEventId]);
+
+	// Verify that the PDU's auth_events contains the kicker's join event, power levels, and create event
+	expect(signedKickEvent.auth_events).toContain(createEventId);
+	expect(signedKickEvent.auth_events).toContain(powerLevelsEventId);
+	expect(signedKickEvent.auth_events).toContain(kickerJoinEventId); 
+
+	expect(kickEventId).toBeDefined();
+	expect(signedKickEvent.signatures[serverName][`${kickerSignature.algorithm}:${kickerSignature.version}`]).toBeString();
+	expect(Object.keys(signedKickEvent.content).length).toBe(2); // membership + reason
+});

--- a/packages/core/src/events/m.room.member.ts
+++ b/packages/core/src/events/m.room.member.ts
@@ -13,6 +13,7 @@ declare module "./eventBase" {
 			content: {
 				join_authorised_via_users_server?: string;
 				membership: Membership;
+				reason?: string;
 			};
 		};
 	}
@@ -49,6 +50,7 @@ export interface RoomMemberEvent extends EventBase {
 				};
 			};
 		};
+		reason?: string;
 	};
 	state_key: string;
 	unsigned: {

--- a/packages/core/src/events/m.room.power_levels.ts
+++ b/packages/core/src/events/m.room.power_levels.ts
@@ -47,6 +47,7 @@ export const roomPowerLevelsEvent = ({
 	auth_events,
 	prev_events,
 	depth,
+	content,
 	ts = Date.now(),
 }: {
 	roomId: string;
@@ -54,6 +55,7 @@ export const roomPowerLevelsEvent = ({
 	auth_events: string[];
 	prev_events: string[];
 	depth: number;
+	content?: RoomPowerLevelsEvent["content"];
 	ts?: number;
 }) => {
 	const [sender, ...members] = usernames;
@@ -64,7 +66,7 @@ export const roomPowerLevelsEvent = ({
 		prev_events,
 		depth,
 		ts,
-		content: {
+		content: content || {
 			users: {
 				[sender]: 100,
 				...Object.fromEntries(usernames.map((member) => [member, 100])),

--- a/packages/homeserver/src/controllers/internal/room.controller.ts
+++ b/packages/homeserver/src/controllers/internal/room.controller.ts
@@ -17,7 +17,28 @@ const UpdateRoomNameDtoSchema = z.object({
   targetServer: z.string().trim().min(1, { message: "Target server must be a non-empty string" }),
 });
 
+const UpdateUserPowerLevelSchema = z.object({
+  senderUserId: z.string().min(1), 
+  powerLevel: z.number().int(), 
+  targetServers: z.array(z.string()).optional(), 
+});
+
+const LeaveRoomDtoSchema = z.object({
+  senderUserId: z.string().trim().min(1, { message: "Sender ID must be a non-empty string" }),
+  targetServers: z.array(z.string()).optional(),
+});
+
+const KickUserDtoSchema = z.object({
+  userIdToKick: z.string().trim().min(1, { message: "User ID to kick must be a non-empty string" }),
+  senderUserId: z.string().trim().min(1, { message: "Sender ID must be a non-empty string" }),
+  reason: z.string().optional(),
+  targetServers: z.array(z.string()).optional(),
+});
+
 type UpdateRoomNameDto = z.infer<typeof UpdateRoomNameDtoSchema>;
+type UpdateUserPowerLevelDto = z.infer<typeof UpdateUserPowerLevelSchema>;
+type LeaveRoomDto = z.infer<typeof LeaveRoomDtoSchema>;
+type KickUserDto = z.infer<typeof KickUserDtoSchema>;
 
 @Controller("internal/rooms")
 export class InternalRoomController {
@@ -60,4 +81,87 @@ export class InternalRoomController {
         );
       }
     }
+
+	@Put("/:roomId/permissions/:userId")
+	async updateUserPowerLevel(
+		@Param("roomId", new ZodValidationPipe(z.string().trim().min(1, { message: "Room ID must be a non-empty string" }))) roomId: string,
+		@Param("userId", new ZodValidationPipe(z.string().trim().min(1, { message: "User ID must be a non-empty string" }))) userId: string,
+		@Body(new ZodValidationPipe(UpdateUserPowerLevelSchema)) body: UpdateUserPowerLevelDto,
+	): Promise<{ eventId: string }> {
+		try {
+			const eventId = await this.roomService.updateUserPowerLevel(
+				roomId,
+				userId,
+				body.powerLevel,
+				body.senderUserId,
+				body.targetServers,
+			);
+			return { eventId };
+		} catch (error) {
+      console.error(error);
+			if (error instanceof HttpException) {
+				throw error;
+			}
+			throw new HttpException(
+				"Failed to update user power level.",
+				HttpStatus.INTERNAL_SERVER_ERROR,
+			);
+		}
+	}
+
+  @Post("/:roomId/leave")
+  async leaveRoomEndpoint(
+    @Param("roomId", new ZodValidationPipe(z.string().trim().min(1, { message: "Room ID must be a non-empty string" }))) roomId: string,
+    @Body(new ZodValidationPipe(LeaveRoomDtoSchema)) body: LeaveRoomDto,
+  ): Promise<{ eventId: string }> {
+    const { senderUserId, targetServers } = body;
+
+    try {
+      const eventId = await this.roomService.leaveRoom(roomId.trim(), senderUserId, targetServers);
+      return { eventId };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        `Failed to leave room: ${error instanceof Error ? error.message : String(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Post("/:roomId/members/:memberId/kick")
+  async kickUserFromRoom(
+    @Param("roomId", new ZodValidationPipe(z.string().trim().min(1, { message: "Room ID must be a non-empty string" }))) roomId: string,
+    @Param("memberId", new ZodValidationPipe(z.string().trim().min(1, { message: "Member ID must be a non-empty string" }))) memberId: string, // This is the user being kicked
+    @Body(new ZodValidationPipe(KickUserDtoSchema)) body: KickUserDto,
+  ): Promise<{ eventId: string }> {
+    const { senderUserId, reason, targetServers } = body;
+
+    if (body.userIdToKick !== memberId) {
+        throw new HttpException(
+            "User ID in path does not match user ID in body (userIdToKick).",
+            HttpStatus.BAD_REQUEST,
+        );
+    }
+
+    try {
+      const eventId = await this.roomService.kickUser(
+        roomId.trim(),
+        memberId,
+        senderUserId,
+        reason,
+        targetServers,
+      );
+      return { eventId };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        `Failed to kick user from room: ${error instanceof Error ? error.message : String(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
 } 

--- a/packages/homeserver/src/services/event.service.ts
+++ b/packages/homeserver/src/services/event.service.ts
@@ -39,34 +39,39 @@ export interface StagedEvent {
 
 export enum EventType {
 	CREATE = "m.room.create",
-	POWER_LEVELS = "m.room.power_levels",
 	MEMBER = "m.room.member",
 	MESSAGE = "m.room.message",
-	JOIN_RULES = "m.room.join_rules",
+	REDACTION = "m.room.redaction",
 	REACTION = "m.reaction",
 	NAME = "m.room.name",
+	POWER_LEVELS = "m.room.power_levels",
 }
 
-// Define what attributes each event type expects
 type EventAttributes = {
 	[EventType.NAME]: { roomId: string; senderId: string };
 	[EventType.MESSAGE]: { roomId: string; senderId: string };
 	[EventType.REACTION]: { roomId: string; senderId: string };
 	[EventType.MEMBER]: { roomId: string; senderId: string };
 	[EventType.CREATE]: { roomId: string };
-	[EventType.POWER_LEVELS]: { roomId: string };
-	[EventType.JOIN_RULES]: { roomId: string };
+	[EventType.POWER_LEVELS]: { roomId: string, senderId: string };
+	[EventType.REDACTION]: { roomId: string; senderId: string };
 };
 
 interface AuthEventResult {
 	_id: string;
-	type: string;
+	type: EventType;
+	state_key?: string;
 }
 
 interface QueryConfig {
 	query: Record<string, any>;
 	sort?: Record<string, 1 | -1>;
 	limit?: number;
+}
+
+export interface AuthEventParams {
+	roomId: string;
+	senderId: string;
 }
 
 @Injectable()
@@ -81,6 +86,11 @@ export class EventService {
 		private readonly stagingAreaQueue: StagingAreaQueue,
 		private readonly federationService: FederationService,
 	) {}
+
+	async getEventById<T extends EventBase>(eventId: string): Promise<T | null> {
+		const event = await this.eventRepository.findById(eventId);
+		return event?.event as T ?? null;
+	}
 
 	async checkIfEventsExists(
 		eventIds: string[],
@@ -628,29 +638,39 @@ export class EventService {
 		return events[0];
 	}
 
-	async getAuthEventIds<T extends EventType>(eventType: T, attributes: EventAttributes[T]): Promise<AuthEventResult[]> {
-		const queries = this.getAuthEventQueries(eventType, attributes);
+	async getAuthEventIds(
+		eventType: EventType,
+		params: AuthEventParams,
+	): Promise<AuthEventResult[]> {
+		const queries = this.getAuthEventQueries(eventType, params);
 		const authEvents: AuthEventResult[] = [];
 
-		for (const query of queries) {
-			try {
-				const events = await this.eventRepository.find(query.query, {
-					sort: query.sort,
-					limit: query.limit
-				});
-
-				if (events.length > 0) {
-					const latestEvent = events[0];
-					authEvents.push({
-						_id: latestEvent._id,
-						type: latestEvent.event.type
-					});
+		for (const queryConfig of queries) {
+			const events = await this.eventRepository.find(
+				queryConfig.query,
+				{
+					sort: queryConfig.sort,
+					limit: queryConfig.limit,
+					projection: { _id: 1, "event.type": 1, "event.state_key": 1 },
 				}
-			} catch (error) {
-				this.logger.error(`Failed to execute query for ${eventType}:`, error);
+			);
+			
+			for (const storeEvent of events) {
+				const currentEventType = storeEvent.event?.type as EventType;
+				const currentStateKey = storeEvent.event?.state_key;
+				const eventTypeKey = Object.keys(EventType).find(key => EventType[key as keyof typeof EventType] === currentEventType);
+
+				if (eventTypeKey && currentEventType) {
+					authEvents.push({ 
+						_id: storeEvent._id, 
+						type: currentEventType,
+						...(currentStateKey !== undefined && { state_key: currentStateKey })
+					});
+				} else {
+					this.logger.warn(`EventStore with id ${storeEvent._id} has an unrecognized event type: ${storeEvent.event?.type}`);
+				}
 			}
 		}
-
 		return authEvents;
 	}
 
@@ -707,10 +727,11 @@ export class EventService {
 			case EventType.POWER_LEVELS:
 				return [
 					baseQueries.create,
-					baseQueries.powerLevels
+					baseQueries.powerLevels,
+					baseQueries.membership
 				];
 
-			case EventType.JOIN_RULES:
+			case EventType.REDACTION:
 				return [
 					baseQueries.create,
 					baseQueries.powerLevels
@@ -721,7 +742,11 @@ export class EventService {
 		}
 	}
 
-	async checkUserPermission(powerLevelsEventId: string, userId: string, eventType: string): Promise<boolean> {
+	async checkUserPermission(
+		powerLevelsEventId: string,
+		userId: string,
+		actionType: EventType,
+	): Promise<boolean> {
 		const powerLevelsEvent = await this.eventRepository.findById(powerLevelsEventId);
 		if (!powerLevelsEvent) {
 			this.logger.warn(`Power levels event ${powerLevelsEventId} not found`);
@@ -731,12 +756,12 @@ export class EventService {
 		const powerLevelsContent = powerLevelsEvent.event.content as RoomPowerLevelsEvent['content'];
 		const userPowerLevel = powerLevelsContent.users?.[userId] ?? powerLevelsContent.users_default ?? 0;
 		
-		let requiredPowerLevel = powerLevelsContent.events?.[eventType];
+		let requiredPowerLevel = powerLevelsContent.events?.[actionType];
 		if (requiredPowerLevel === undefined) {
 			requiredPowerLevel = powerLevelsContent.events_default ?? 0;
 		}
 
-		this.logger.debug(`Permission check for ${userId} to send ${eventType}: UserLevel=${userPowerLevel}, RequiredLevel=${requiredPowerLevel}`);
+		this.logger.debug(`Permission check for ${userId} to send ${actionType}: UserLevel=${userPowerLevel}, RequiredLevel=${requiredPowerLevel}`);
 		return userPowerLevel >= requiredPowerLevel;
 	}
 }


### PR DESCRIPTION
Adds support for updating user power levels via the internal endpoint `PUT /internal/rooms/:roomId/permissions/:userId`, as specified in [FDR-41](https://rocketchat.atlassian.net/browse/FDR-41).

[FDR-41]: https://rocketchat.atlassian.net/browse/FDR-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ