### PR TITLE
feat: leave room

### DIFF
--- a/packages/core/src/events/m.room.member.ts
+++ b/packages/core/src/events/m.room.member.ts
@@ -13,6 +13,7 @@ declare module "./eventBase" {
 			content: {
 				join_authorised_via_users_server?: string;
 				membership: Membership;
+				reason?: string;
 			};
 		};
 	}
@@ -49,6 +50,7 @@ export interface RoomMemberEvent extends EventBase {
 				};
 			};
 		};
+		reason?: string;
 	};
 	state_key: string;
 	unsigned: {


### PR DESCRIPTION
Adds support for leaving a room via the internal endpoint `POST /internal/rooms/:roomId/leave`, as specified in [FDR-42](https://rocketchat.atlassian.net/browse/FDR-42).

[FDR-42]: https://rocketchat.atlassian.net/browse/FDR-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ