### PR TITLE
feat: adds kick user from room

### DIFF
--- a/packages/core/src/events/m.room.member.ts
+++ b/packages/core/src/events/m.room.member.ts
@@ -13,6 +13,7 @@ declare module "./eventBase" {
 			content: {
 				join_authorised_via_users_server?: string;
 				membership: Membership;
+				reason?: string;
 			};
 		};
 	}
@@ -49,6 +50,7 @@ export interface RoomMemberEvent extends EventBase {
 				};
 			};
 		};
+		reason?: string;
 	};
 	state_key: string;
 	unsigned: {


### PR DESCRIPTION
Implements support for kicking a user from a room via the internal endpoint `POST /internal/rooms/:roomId/members/:memberId/kick`, as specified in [FDR-43](https://rocketchat.atlassian.net/browse/FDR-43).

Note:
We are currently not validating whether the user is a member of the room before kicking them. This decision was made intentionally, as in the near future we plan to rely on room state handling - which may include a cache or a more efficient membership lookup mechanism - to improve accuracy and performance in such validations.

[FDR-43]: https://rocketchat.atlassian.net/browse/FDR-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ