### PR TITLE
feat: adds lock mechanism

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -796,7 +796,7 @@
 
     "@bogeychan/elysia-logger/pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
 
-    "@hs/core/elysia": ["elysia@1.3.3", "", { "dependencies": { "cookie": "^1.0.2", "exact-mirror": "0.1.2", "fast-decode-uri-component": "^1.0.1" }, "optionalDependencies": { "@sinclair/typebox": "^0.34.33", "openapi-types": "^12.1.3" }, "peerDependencies": { "file-type": ">= 20.0.0", "typescript": ">= 5.0.0" } }, "sha512-x6a89d4h0xX9TB0CSGkUuKNqIK776HBJw0WHtK1B3ViQqZijsLnOor6be/7TwVl8MG6m59NHGHbmbBS6lnCXSw=="],
+    "@hs/core/elysia": ["elysia@1.3.4", "", { "dependencies": { "cookie": "^1.0.2", "exact-mirror": "0.1.2", "fast-decode-uri-component": "^1.0.1" }, "optionalDependencies": { "@sinclair/typebox": "^0.34.33", "openapi-types": "^12.1.3" }, "peerDependencies": { "file-type": ">= 20.0.0", "typescript": ">= 5.0.0" } }, "sha512-kAfM3Zwovy3z255IZgTKVxBw91HbgKhYl3TqrGRdZqqr+Fd+4eKOfvxgaKij22+MZLczPzIHtscAmvfpI3+q/A=="],
 
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 

--- a/packages/homeserver/src/listeners/staging-area.listener.ts
+++ b/packages/homeserver/src/listeners/staging-area.listener.ts
@@ -1,8 +1,10 @@
+import { injectable } from 'tsyringe';
+import type { StagingAreaEventType } from '../queues/staging-area.queue';
 import { StagingAreaQueue } from '../queues/staging-area.queue';
 import { StagingAreaService } from '../services/staging-area.service';
 import { createLogger } from '../utils/logger';
-import type { StagingAreaEventType } from '../queues/staging-area.queue';
 
+@injectable()
 export class StagingAreaListener {
 	private readonly logger = createLogger('StagingAreaListener');
 

--- a/packages/homeserver/src/queues/missing-event.queue.ts
+++ b/packages/homeserver/src/queues/missing-event.queue.ts
@@ -1,3 +1,4 @@
+import { injectable } from 'tsyringe';
 import { BaseQueue } from './base.queue';
 
 export type MissingEventType = {
@@ -6,4 +7,5 @@ export type MissingEventType = {
 	origin: string;
 };
 
+@injectable()
 export class MissingEventsQueue extends BaseQueue<MissingEventType> {}

--- a/packages/homeserver/src/queues/staging-area.queue.ts
+++ b/packages/homeserver/src/queues/staging-area.queue.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { injectable } from 'tsyringe';
 import type { EventBase } from '../models/event.model';
 
 export interface StagingAreaEventType {
@@ -11,6 +12,7 @@ export interface StagingAreaEventType {
 
 type QueueHandler = (item: StagingAreaEventType) => Promise<void>;
 
+@injectable()
 export class StagingAreaQueue {
 	private queue: StagingAreaEventType[] = [];
 	private handlers: QueueHandler[] = [];

--- a/packages/homeserver/src/services/event.service.ts
+++ b/packages/homeserver/src/services/event.service.ts
@@ -1,6 +1,7 @@
 import type { RoomPowerLevelsEvent } from '@hs/core/src/events/m.room.power_levels';
+import type { RedactionEvent } from '@hs/core/src/events/m.room.redaction';
 import { FederationService } from '@hs/federation-sdk';
-import { createLogger } from '../utils/logger';
+import { injectable } from 'tsyringe';
 import type { z } from 'zod';
 import { generateId } from '../authentication';
 import { MatrixError } from '../errors';
@@ -9,16 +10,15 @@ import {
 	getPublicKeyFromRemoteServer,
 	makeGetPublicKeyFromServerProcedure,
 } from '../procedures/getPublicKeyFromServer';
+import { pruneEventDict } from '../pruneEventDict';
 import { StagingAreaQueue } from '../queues/staging-area.queue';
 import { EventRepository } from '../repositories/event.repository';
 import { KeyRepository } from '../repositories/key.repository';
 import { RoomRepository } from '../repositories/room.repository';
 import { checkSignAndHashes } from '../utils/checkSignAndHashes';
 import { eventSchemas } from '../utils/event-schemas';
+import { createLogger } from '../utils/logger';
 import { ConfigService } from './config.service';
-import type { RedactionEvent } from '@hs/core/src/events/m.room.redaction';
-import { pruneEventDict } from '../pruneEventDict';
-import { injectable } from 'tsyringe';
 
 type ValidationResult = {
 	eventId: string;

--- a/packages/homeserver/src/services/staging-area.service.ts
+++ b/packages/homeserver/src/services/staging-area.service.ts
@@ -1,14 +1,15 @@
-import { createLogger } from '../utils/logger';
+import { injectable } from 'tsyringe';
 import type { EventBase } from '../models/event.model';
 import {
 	type StagingAreaEventType,
 	StagingAreaQueue,
 } from '../queues/staging-area.queue';
+import { Lock } from '../utils/lock.decorator';
+import { createLogger } from '../utils/logger';
 import { EventAuthorizationService } from './event-authorization.service';
 import { EventStateService } from './event-state.service';
 import { EventService, EventType } from './event.service';
 import { MissingEventService } from './missing-event.service';
-import { injectable } from 'tsyringe';
 
 // ProcessingState indicates where in the flow an event is
 enum ProcessingState {
@@ -79,6 +80,7 @@ export class StagingAreaService {
 		return [...authEvents, ...prevEvents];
 	}
 
+	@Lock({ timeout: 10000, keyPath: 'event.room_id' })
 	async processEvent(event: StagingAreaEventType & { metadata?: any }) {
 		const eventId = event.eventId;
 		const trackedEvent = this.processingEvents.get(eventId);

--- a/packages/homeserver/src/utils/lock.decorator.spec.ts
+++ b/packages/homeserver/src/utils/lock.decorator.spec.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { container } from 'tsyringe';
+import { Lock, LockManagerService, type MemoryLockConfig, type NatsLockConfig } from './lock.decorator';
+
+describe('Lock Decorator', () => {
+	beforeEach(() => {
+		// Clear the container and register the service fresh for each test
+		container.clearInstances();
+		container.register(LockManagerService, {
+			useFactory: () => new LockManagerService({ type: 'memory' })
+		});
+	});
+
+	describe('Basic Locking Functionality', () => {
+		test('should allow sequential execution of locked methods', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					await new Promise(resolve => setTimeout(resolve, 50));
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result1 = await service.processUser('user1');
+			const result2 = await service.processUser('user2');
+
+			expect(result1).toBe('processed-user1');
+			expect(result2).toBe('processed-user2');
+		});
+
+		test('should prevent concurrent execution for same key', async () => {
+			const executionOrder: string[] = [];
+
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					executionOrder.push(`start-${userId}`);
+					await new Promise(resolve => setTimeout(resolve, 100));
+					executionOrder.push(`end-${userId}`);
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			const promise1 = service.processUser('user1');
+			const promise2 = service.processUser('user1');
+
+			await Promise.all([promise1, promise2]);
+
+			expect(executionOrder).toEqual([
+				'start-user1',
+				'end-user1',
+				'start-user1',
+				'end-user1'
+			]);
+		});
+
+		test('should allow concurrent execution for different keys', async () => {
+			const executionOrder: string[] = [];
+
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					executionOrder.push(`start-${userId}`);
+					await new Promise(resolve => setTimeout(resolve, 100));
+					executionOrder.push(`end-${userId}`);
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			const promise1 = service.processUser('user1');
+			const promise2 = service.processUser('user2');
+
+			await Promise.all([promise1, promise2]);
+
+			expect(executionOrder).toContain('start-user1');
+			expect(executionOrder).toContain('start-user2');
+			expect(executionOrder).toContain('end-user1');
+			expect(executionOrder).toContain('end-user2');
+		});
+	});
+
+	describe('Key Extraction', () => {
+		test('should extract key from simple string parameter', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result = await service.processUser('test-user');
+			expect(result).toBe('processed-test-user');
+		});
+
+		test('should extract key from object property', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processRequest(request: { userId: string; action: string }): Promise<string> {
+					return `processed-${request.userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result = await service.processRequest({ userId: 'test-user', action: 'update' });
+			expect(result).toBe('processed-test-user');
+		});
+
+		test('should extract key from nested object path', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'request.userId' })
+				async processData(data: { request: { userId: string; data: any } }): Promise<string> {
+					return `processed-${data.request.userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result = await service.processData({ request: { userId: 'nested-user', data: {} } });
+			expect(result).toBe('processed-nested-user');
+		});
+
+		test('should throw error for invalid key path', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'nonexistent' })
+				async processUser(userId: string): Promise<string> {
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			await expect(service.processUser('test-user')).rejects.toThrow('Could not find parameter');
+		});
+
+		test('should throw error for null/undefined in path', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'request.userId' })
+				async processData(data: { request: null }): Promise<string> {
+					return 'processed';
+				}
+			}
+
+			const service = new TestService();
+			
+			await expect(service.processData({ request: null })).rejects.toThrow('leads to null/undefined value');
+		});
+	});
+
+	describe('Error Handling', () => {
+		test('should release lock even if method throws error', async () => {
+			const executionOrder: string[] = [];
+
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string, shouldThrow = false): Promise<string> {
+					executionOrder.push(`start-${userId}`);
+					if (shouldThrow) {
+						throw new Error('Test error');
+					}
+					await new Promise(resolve => setTimeout(resolve, 50));
+					executionOrder.push(`end-${userId}`);
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			await expect(service.processUser('user1', true)).rejects.toThrow('Test error');
+			
+			const result = await service.processUser('user1', false);
+			
+			expect(result).toBe('processed-user1');
+			expect(executionOrder).toEqual(['start-user1', 'start-user1', 'end-user1']);
+		});
+
+		test('should handle multiple errors correctly', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					throw new Error(`Error for ${userId}`);
+				}
+			}
+
+			const service = new TestService();
+			
+			await expect(service.processUser('user1')).rejects.toThrow('Error for user1');
+			await expect(service.processUser('user1')).rejects.toThrow('Error for user1');
+		});
+	});
+
+	describe('Timeout Behavior', () => {
+		test('should release lock after timeout', async () => {
+			let lockReleased = false;
+
+			class TestService {
+				@Lock({ timeout: 100, keyPath: 'userId' })
+				async longRunningProcess(userId: string): Promise<string> {
+					await new Promise(resolve => setTimeout(resolve, 200));
+					lockReleased = true;
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			const promise = service.longRunningProcess('user1');
+			
+			await new Promise(resolve => setTimeout(resolve, 150));
+			
+			await promise;
+			expect(lockReleased).toBe(true);
+		}, 500);
+	});
+
+	describe('Method Context', () => {
+		test('should preserve method context (this)', async () => {
+			class TestService {
+				private prefix = 'service';
+
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					return `${this.prefix}-processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result = await service.processUser('test-user');
+			expect(result).toBe('service-processed-test-user');
+		});
+
+		test('should work with different method names', async () => {
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'id' })
+				async methodA(id: string): Promise<string> {
+					return `methodA-${id}`;
+				}
+
+				@Lock({ timeout: 1000, keyPath: 'id' })
+				async methodB(id: string): Promise<string> {
+					return `methodB-${id}`;
+				}
+			}
+
+			const service = new TestService();
+			
+			const promise1 = service.methodA('test');
+			const promise2 = service.methodB('test');
+			
+			const [result1, result2] = await Promise.all([promise1, promise2]);
+			
+			expect(result1).toBe('methodA-test');
+			expect(result2).toBe('methodB-test');
+		});
+	});
+
+	describe('Lock Provider Configuration', () => {
+		test('should work with memory configuration', async () => {
+			// Re-register with explicit memory config for this test
+			container.clearInstances();
+			const memoryConfig: MemoryLockConfig = { type: 'memory' };
+			container.register(LockManagerService, {
+				useFactory: () => new LockManagerService(memoryConfig)
+			});
+
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			const result = await service.processUser('test-user');
+			expect(result).toBe('processed-test-user');
+			
+			// Verify configuration
+			const lockManager = container.resolve(LockManagerService);
+			expect(lockManager.getConfig()).toEqual({ type: 'memory' });
+		});
+
+		test('should throw error for NATS configuration (not implemented yet)', async () => {
+			// Re-register with NATS config for this test
+			container.clearInstances();
+			const natsConfig: NatsLockConfig = {
+				type: 'nats',
+				servers: ['nats://localhost:4222'],
+				timeout: 5000,
+				reconnect: true
+			};
+			container.register(LockManagerService, {
+				useFactory: () => new LockManagerService(natsConfig)
+			});
+
+			class TestService {
+				@Lock({ timeout: 1000, keyPath: 'userId' })
+				async processUser(userId: string): Promise<string> {
+					return `processed-${userId}`;
+				}
+			}
+
+			const service = new TestService();
+			await expect(service.processUser('test-user')).rejects.toThrow(/NATS package not installed|CONNECTION_REFUSED|Failed to connect to NATS/);
+			
+			// Verify configuration is properly set
+			const lockManager = container.resolve(LockManagerService);
+			expect(lockManager.getConfig()).toEqual(natsConfig);
+		});
+
+		test('should support NATS configuration with custom options', async () => {
+			container.clearInstances();
+			const natsConfig: NatsLockConfig = {
+				type: 'nats',
+				servers: ['nats://localhost:4222', 'nats://backup:4222'],
+				timeout: 10000,
+				reconnect: true,
+				maxReconnectAttempts: 5,
+				lockStreamName: 'CUSTOM_LOCKS',
+				lockTtlMs: 600000
+			};
+			container.register(LockManagerService, {
+				useFactory: () => new LockManagerService(natsConfig)
+			});
+
+			// Verify configuration is properly set
+			const lockManager = container.resolve(LockManagerService);
+			expect(lockManager.getConfig()).toEqual(natsConfig);
+		});
+
+		test('should support cleanup for external providers', async () => {
+			const lockManager = container.resolve(LockManagerService);
+			
+			// Should not throw for memory provider (no cleanup needed)
+			await expect(lockManager.cleanup()).resolves.toBeUndefined();
+		});
+	});
+}); 

--- a/packages/homeserver/src/utils/lock.decorator.ts
+++ b/packages/homeserver/src/utils/lock.decorator.ts
@@ -1,0 +1,380 @@
+import { container, injectable } from 'tsyringe';
+
+export type MemoryLockConfig = {
+	type: 'memory';
+};
+
+export type NatsLockConfig = {
+	type: 'nats';
+	servers: string[];
+	timeout?: number;
+	reconnect?: boolean;
+	maxReconnectAttempts?: number;
+	lockStreamName?: string;
+	lockTtlMs?: number;
+};
+
+export type ExternalLockConfig = NatsLockConfig;
+
+export type LockConfig = MemoryLockConfig | ExternalLockConfig;
+
+export interface ILockProvider {
+	acquireLock(key: string, timeoutMs: number): Promise<() => void>;
+	cleanup?(): Promise<void>;
+}
+
+class InMemoryLockProvider implements ILockProvider {
+	private static instance: InMemoryLockProvider;
+	private locks = new Map<string, Promise<void>>();
+
+	static getInstance(): InMemoryLockProvider {
+		if (!InMemoryLockProvider.instance) {
+			InMemoryLockProvider.instance = new InMemoryLockProvider();
+		}
+		return InMemoryLockProvider.instance;
+	}
+
+	async acquireLock(key: string, timeoutMs: number): Promise<() => void> {
+		while (this.locks.has(key)) {
+			try {
+				await this.locks.get(key);
+			} catch {}
+		}
+
+		let releaseFn: (value?: any) => void;
+		
+		const lockPromise = new Promise<void>((resolve) => {
+			releaseFn = resolve;
+		});
+
+		this.locks.set(key, lockPromise);
+
+		const timeoutHandle = setTimeout(() => {
+			this.locks.delete(key);
+			releaseFn();
+		}, timeoutMs);
+
+		return () => {
+			clearTimeout(timeoutHandle);
+			this.locks.delete(key);
+			releaseFn();
+		};
+	}
+}
+
+// NATS types (these would come from 'nats' package in real implementation)
+type NatsConnection = any;
+type JetStreamManager = any;
+type JetStream = any;
+type Consumer = any;
+
+class NatsLockProvider implements ILockProvider {
+	private connection: NatsConnection | null = null;
+	private jsm: JetStreamManager | null = null;
+	private js: JetStream | null = null;
+	private config: NatsLockConfig;
+	private readonly streamName: string;
+	private readonly lockPrefix = 'lock.';
+
+	constructor(config: NatsLockConfig) {
+		this.config = config;
+		this.streamName = config.lockStreamName || 'LOCKS';
+	}
+
+	private async ensureConnection(): Promise<void> {
+		if (this.connection && !this.connection.isClosed()) {
+			return;
+		}
+
+		try {
+			// Dynamic import to handle optional NATS dependency
+			const { connect } = await import('nats').catch(() => {
+				throw new Error('NATS package not installed. Run: bun add nats');
+			});
+
+			this.connection = await connect({
+				servers: this.config.servers,
+				timeout: this.config.timeout || 5000,
+				reconnect: this.config.reconnect !== false,
+				maxReconnectAttempts: this.config.maxReconnectAttempts || 10,
+			});
+
+			this.js = this.connection.jetstream();
+			this.jsm = await this.js.jetstreamManager();
+
+			await this.ensureStream();
+		} catch (error) {
+			throw new Error(`Failed to connect to NATS: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private async ensureStream(): Promise<void> {
+		if (!this.jsm) {
+			throw new Error('JetStream manager not initialized');
+		}
+
+		try {
+			await this.jsm.streams.info(this.streamName);
+		} catch {
+			await this.jsm.streams.add({
+				name: this.streamName,
+				subjects: [`${this.lockPrefix}*`],
+				retention: 'workqueue' as any,
+				max_age: (this.config.lockTtlMs || 300000) * 1_000_000, // Convert ms to nanoseconds
+				max_msgs: 10000,
+				discard: 'old' as any,
+			});
+		}
+	}
+
+	async acquireLock(key: string, timeoutMs: number): Promise<() => void> {
+		await this.ensureConnection();
+
+		if (!this.connection || !this.jsm || !this.js) {
+			throw new Error('NATS connection not established');
+		}
+
+		const lockSubject = `${this.lockPrefix}${key}`;
+		const consumerName = `lock-${key}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+		
+		try {
+			// Publish lock acquisition message
+			const lockPayload = JSON.stringify({
+				owner: `${process.pid}-${Date.now()}`,
+				acquired_at: new Date().toISOString(),
+				timeout_ms: timeoutMs,
+			});
+
+			await this.js.publish(lockSubject, new TextEncoder().encode(lockPayload));
+
+			// Create consumer to try to get the lock message
+			const consumer = await this.js.consumers.get(this.streamName, {
+				name: consumerName,
+				filter_subject: lockSubject,
+				deliver_policy: 'new' as any,
+				ack_policy: 'explicit' as any,
+				max_deliver: 1,
+				inactive_threshold: timeoutMs * 1_000_000,
+			});
+
+			// Try to consume our message
+			const messages = await consumer.consume({ max_messages: 1 });
+			
+			let lockAcquired = false;
+			let messageToAck: any = null;
+
+			for await (const message of messages) {
+				lockAcquired = true;
+				messageToAck = message;
+				break;
+			}
+
+			if (!lockAcquired) {
+				await this.waitForLockRelease(lockSubject, timeoutMs);
+				return this.acquireLock(key, timeoutMs);
+			}
+
+			// Set up automatic release
+			const timeoutHandle = setTimeout(async () => {
+				if (messageToAck) {
+					messageToAck.ack();
+				}
+				await this.cleanupConsumer(consumerName);
+			}, timeoutMs);
+
+			return async () => {
+				clearTimeout(timeoutHandle);
+				if (messageToAck) {
+					messageToAck.ack();
+				}
+				await this.cleanupConsumer(consumerName);
+			};
+
+		} catch (error) {
+			await this.cleanupConsumer(consumerName);
+			throw new Error(`Failed to acquire lock for key "${key}": ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private async waitForLockRelease(lockSubject: string, timeoutMs: number): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				reject(new Error(`Timeout waiting for lock release: ${lockSubject}`));
+			}, timeoutMs);
+
+			// Simple backoff strategy - in production you might want more sophisticated monitoring
+			setTimeout(() => {
+				clearTimeout(timeout);
+				resolve();
+			}, Math.min(100, timeoutMs / 10));
+		});
+	}
+
+	private async cleanupConsumer(consumerName: string): Promise<void> {
+		try {
+			if (this.jsm) {
+				await this.jsm.consumers.delete(this.streamName, consumerName);
+			}
+		} catch {
+			// Ignore cleanup errors
+		}
+	}
+
+	async cleanup(): Promise<void> {
+		if (this.connection && !this.connection.isClosed()) {
+			await this.connection.close();
+			this.connection = null;
+			this.jsm = null;
+			this.js = null;
+		}
+	}
+}
+
+class LockProviderFactory {
+	static create(config: LockConfig): ILockProvider {
+		switch (config.type) {
+			case 'memory':
+				return InMemoryLockProvider.getInstance();
+			
+			case 'nats':
+				return new NatsLockProvider(config);
+			
+			default:
+				throw new Error(`Unsupported lock provider type: ${JSON.stringify(config)}`);
+		}
+	}
+}
+
+@injectable()
+export class LockManagerService {
+	private provider: ILockProvider;
+	private config: LockConfig;
+
+	constructor(config: LockConfig = { type: 'memory' }) {
+		this.config = config;
+		this.provider = LockProviderFactory.create(config);
+	}
+
+	async acquireLock(key: string, timeoutMs: number): Promise<() => void> {
+		return this.provider.acquireLock(key, timeoutMs);
+	}
+
+	getConfig(): LockConfig {
+		return { ...this.config };
+	}
+
+	async cleanup(): Promise<void> {
+		if (this.provider.cleanup) {
+			await this.provider.cleanup();
+		}
+	}
+}
+
+function getLockManagerService(): LockManagerService {
+	try {
+		return container.resolve(LockManagerService);
+	} catch (error) {
+		throw new Error('LockManagerService not registered. Make sure to register it as a singleton in your DI container.');
+	}
+}
+
+export interface LockOptions {
+	timeout: number;
+	keyPath: string;
+}
+
+/**
+ * Locking decorator that provides mutual exclusion based on a key extracted from function parameters
+ * 
+ * @param options Configuration for the lock including timeout and key extraction path
+ * 
+ * @example
+ * ```typescript
+ * class UserService {
+ *   @Lock({ timeout: 5000, keyPath: 'userId' })
+ *   async updateUser(userId: string, data: any) {
+ *     // This method will be locked per userId
+ *   }
+ * 
+ *   @Lock({ timeout: 10000, keyPath: 'request.roomId' })
+ *   async joinRoom(request: { roomId: string, userId: string }) {
+ *     // This method will be locked per roomId
+ *   }
+ * }
+ * ```
+ */
+export function Lock(options: LockOptions) {
+	return <T extends (...args: any[]) => Promise<any>>(
+		_target: any,
+		propertyName: string,
+		descriptor: TypedPropertyDescriptor<T>
+	) => {
+		const originalMethod = descriptor.value;
+		
+		if (!originalMethod) {
+			throw new Error('Lock decorator can only be applied to methods');
+		}
+
+		descriptor.value = async function (this: any, ...args: any[]) {
+			const lockKey = extractLockKey(args, options.keyPath, propertyName);
+			
+			const lockManagerService = getLockManagerService();
+			
+			const releaseLock = await lockManagerService.acquireLock(lockKey, options.timeout);
+			
+			try {
+				return await originalMethod.apply(this, args);
+			} finally {
+				releaseLock();
+			}
+		} as T;
+
+		return descriptor;
+	};
+}
+
+function extractLockKey(args: any[], keyPath: string, methodName: string): string {
+	try {
+		const pathParts = keyPath.split('.');
+		
+		if (pathParts.length === 1) {
+			const paramName = pathParts[0];
+			
+			if (args.length > 0) {
+				if (typeof args[0] === 'string' || typeof args[0] === 'number') {
+					if (['userId', 'id', 'roomId', 'eventId', 'fileId', 'tableId'].includes(paramName)) {
+						return `${methodName}:${String(args[0])}`;
+					}
+				}
+				
+				if (typeof args[0] === 'object' && args[0] !== null && paramName in args[0]) {
+					const value = args[0][paramName];
+					if (value !== undefined && value !== null) {
+						return `${methodName}:${String(value)}`;
+					}
+				}
+			}
+			
+			throw new Error(`Could not find parameter '${paramName}' in method arguments`);
+		}
+		
+		let current = args[0];
+		for (const part of pathParts) {
+			if (current === null || current === undefined) {
+				throw new Error(`Path '${keyPath}' leads to null/undefined value`);
+			}
+			if (typeof current !== 'object') {
+				throw new Error(`Path '${keyPath}' expects object but found ${typeof current}`);
+			}
+			current = current[part];
+		}
+		
+		if (current === undefined || current === null) {
+			throw new Error(`Could not extract lock key from path '${keyPath}'`);
+		}
+		
+		return `${methodName}:${String(current)}`;
+	} catch (error) {
+		throw new Error(`Failed to extract lock key from path '${keyPath}': ${error instanceof Error ? error.message : String(error)}`);
+	}
+}


### PR DESCRIPTION
This PR introduces a `@Lock` decorator that enables mutual exclusion for method execution within the same Node.js process.

- In-memory lock manager to prevent race conditions on critical operations
- Customizable timeout for automatic lock release
- Supports nested keyPath to extract lock keys from arguments
- Safe by default: auto-releases lock even if an error is thrown

Example usage:
```typescript
@Lock({ timeout: 5000, keyPath: 'userId' })
async updateUser(userId: string) {
  // Prevents concurrent updates for the same userId
}
```