### PR TITLE
chore: add state related method implementations from join-room pr

### DIFF
--- a/packages/core/src/utils/signEvent.ts
+++ b/packages/core/src/utils/signEvent.ts
@@ -9,9 +9,12 @@ export const signEvent = async <T extends EventBase>(
 	event: T,
 	signature: SigningKey,
 	signingName: string,
+	prune = true,
 ): Promise<SignedEvent<T>> => {
 	// Compute hash and sign
-	const eventToSign = pruneEventDict(computeAndMergeHash(event));
+	const eventToSign = prune
+		? pruneEventDict(computeAndMergeHash(event))
+		: event;
 	const signedJsonResult = await signJson(eventToSign, signature, signingName);
 	// For non-redaction events, restore the original content
 

--- a/packages/federation-sdk/src/repositories/event.repository.ts
+++ b/packages/federation-sdk/src/repositories/event.repository.ts
@@ -212,11 +212,11 @@ export class EventRepository {
 		return collection.findOne(
 			{
 				'event.room_id': roomId,
-				'event.origin_server_ts': { $lt: timestamp },
+				'event.origin_server_ts': { $lt: timestamp }, // events before passed timestamp
 			},
 			{
 				sort: {
-					'event.origin_server_ts': -1,
+					createdAt: -1, // but fetch latest one that was persisted
 				},
 			},
 		);

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -1,14 +1,16 @@
 import { inject, singleton } from 'tsyringe';
-import type { EventID, StateMapKey } from '@hs/room';
+import { StateRepository } from '../repositories/state.repository';
+import { EventRepository } from '../repositories/event.repository';
+import type { StateMapKey } from '@hs/room';
 import type { EventStore, PersistentEventBase } from '@hs/room';
 import { PersistentEventFactory } from '@hs/room';
 import type { RoomVersion } from '@hs/room';
 import { resolveStateV2Plus } from '@hs/room';
 import type { PduCreateEventContent } from '@hs/room';
-import { createLogger } from '@hs/core';
-import { MongoError, ObjectId } from 'mongodb';
-import type { StateRepository } from '../repositories/state.repository';
-import type { EventRepository } from '../repositories/event.repository';
+import { createLogger } from '../utils/logger';
+import { ConfigService } from './config.service';
+import { signEvent } from '@hs/core';
+import { checkEventAuthWithState } from '@hs/room';
 
 type State = Map<StateMapKey, PersistentEventBase>;
 
@@ -20,7 +22,31 @@ export class StateService {
 		private readonly stateRepository: StateRepository,
 		@inject('EventRepository')
 		private readonly eventRepository: EventRepository,
+		@inject('ConfigService') private readonly configService: ConfigService,
 	) {}
+
+	async getRoomInformation(roomId: string): Promise<PduCreateEventContent> {
+		const stateCollection = await this.stateRepository.getCollection();
+
+		const createEventMapping = await stateCollection.findOne({
+			roomId,
+			'delta.identifier': 'm.room.create:',
+		});
+
+		if (!createEventMapping) {
+			throw new Error('Create event mapping not found for room information');
+		}
+
+		const createEvent = await this.eventRepository.findById(
+			createEventMapping.delta.eventId,
+		);
+
+		if (!createEvent) {
+			throw new Error('Create event not found for room information');
+		}
+
+		return createEvent?.event.content as PduCreateEventContent;
+	}
 
 	async getRoomVersion(roomId: string): Promise<RoomVersion | undefined> {
 		const events = await this.eventRepository.getCollection();
@@ -30,7 +56,7 @@ export class StateService {
 			'event.room_id': roomId,
 		});
 		if (!createEvent) {
-			throw new Error('Create event not found');
+			throw new Error('Create event not found for room version');
 		}
 
 		return createEvent.event.content?.room_version as RoomVersion;
@@ -167,19 +193,22 @@ export class StateService {
 				throw new Error('Event not found');
 			}
 
-			finalState.set(
-				stateKey as StateMapKey,
-				PersistentEventFactory.createFromRawEvent(
-					event.event as any,
-					roomVersion,
-				),
+			const pdu = PersistentEventFactory.createFromRawEvent(
+				event.event as any,
+				roomVersion,
 			);
+
+			if (pdu.eventId !== eventId) {
+				throw new Error('Event id mismatch in trying to room state');
+			}
+
+			finalState.set(stateKey as StateMapKey, pdu);
 		}
 
 		return finalState;
 	}
 
-	private _getStore(roomVersion: RoomVersion): EventStore {
+	public _getStore(roomVersion: RoomVersion): EventStore {
 		const cache = new Map<string, PersistentEventBase>();
 
 		return {
@@ -213,7 +242,59 @@ export class StateService {
 		};
 	}
 
-	async _persistEventAgainstState(
+	async addAuthEvents(event: PersistentEventBase) {
+		const state = await this.getFullRoomState(event.roomId);
+
+		const eventsNeeded = event.getAuthEventStateKeys();
+
+		for (const stateKey of eventsNeeded) {
+			const authEvent = state.get(stateKey);
+			if (authEvent) {
+				event.authedBy(authEvent);
+			}
+		}
+	}
+
+	async addPrevEvents(event: PersistentEventBase) {
+		const roomVersion = await this.getRoomVersion(event.roomId);
+		if (!roomVersion) {
+			throw new Error('Room version not found while filling prev events');
+		}
+
+		const prevEvents = await this.eventRepository.findPrevEvents(event.roomId);
+
+		for (const prevEvent of prevEvents) {
+			const e = PersistentEventFactory.createFromRawEvent(
+				prevEvent.event as any,
+				roomVersion,
+			);
+			event.addPreviousEvent(e);
+		}
+	}
+
+	public async signEvent(event: PersistentEventBase) {
+		const signingKey = await this.configService.getSigningKey();
+
+		const origin = this.configService.getServerName();
+
+		const result = await signEvent(
+			// Before signing the event, the content hash of the event is calculated as described below. The hash is encoded using Unpadded Base64 and stored in the event object, in a hashes object, under a sha256 key.
+			// ^^ is done already through redactedEvent fgetter
+			// The event object is then redacted, following the redaction algorithm. Finally it is signed as described in Signing JSON, using the server’s signing key (see also Retrieving server keys).
+			event.redactedEvent as any,
+			signingKey[0],
+			origin,
+			false, // already passed through redactedEvent, hash is already part of this
+		);
+
+		const keyId = `${signingKey[0].algorithm}:${signingKey[0].version}`;
+
+		event.addSignature(origin, keyId, result.signatures[origin][keyId]);
+
+		return event;
+	}
+
+	private async _persistEventAgainstState(
 		event: PersistentEventBase,
 		state: State,
 	): Promise<void> {
@@ -250,12 +331,19 @@ export class StateService {
 		const hasConflict = state.has(event.getUniqueStateIdentifier());
 
 		if (!hasConflict) {
+			await checkEventAuthWithState(event, state, this._getStore(roomVersion));
+			if (event.rejected) {
+				throw new Error(event.rejectedReason);
+			}
+
 			// save the state mapping
 			const { insertedId: stateMappingId } =
 				await this.stateRepository.createStateMapping(event, prevStateIds);
 
+			const signedEvent = await this.signEvent(event);
+
 			this.eventRepository.create(
-				event.event as any /* TODO: fix this with type unifi */,
+				signedEvent.event as any,
 				event.eventId,
 				stateMappingId.toString(),
 			);
@@ -284,8 +372,7 @@ export class StateService {
 			this.eventRepository.create(
 				resolvedEvent.event as any /* TODO: fix this with type unifi */,
 				resolvedEvent.eventId,
-				undefined,
-				// no stateId should indicate not being part of the timeline
+				'',
 			);
 			return;
 		}
@@ -298,8 +385,10 @@ export class StateService {
 				prevStateIds,
 			);
 
+		const signedEvent = await this.signEvent(resolvedEvent);
+
 		await this.eventRepository.create(
-			resolvedEvent.event as any /* TODO: fix this with type unifi */,
+			signedEvent.event as any,
 			resolvedEvent.eventId,
 			stateMappingId.toString(),
 		);
@@ -307,6 +396,11 @@ export class StateService {
 
 	// checks for conflicts, saves the event along with the new state
 	async persistStateEvent(event: PersistentEventBase): Promise<void> {
+		const exists = await this.eventRepository.findById(event.eventId);
+		if (exists) {
+			return;
+		}
+
 		const roomVersion = event.isCreateEvent()
 			? (event.getContent<PduCreateEventContent>().room_version as RoomVersion)
 			: await this.getRoomVersion(event.roomId);
@@ -314,6 +408,7 @@ export class StateService {
 		if (!roomVersion) {
 			throw new Error('Room version not found');
 		}
+
 		const lastEvent =
 			await this.eventRepository.findLatestEventByRoomIdBeforeTimestamp(
 				event.roomId,
@@ -342,7 +437,7 @@ export class StateService {
 			lastState?._id?.toString(),
 		);
 
-		const state = await this.findStateAtEvent(lastEvent._id);
+		const state = await this.findStateAtEvent(lastEvent.eventId);
 
 		await this._persistEventAgainstState(event, state);
 
@@ -395,10 +490,12 @@ export class StateService {
 					// state did not change
 					// just persist the event
 					// TODO: mark rejected, although no code yet uses it so let it go
+					const signedEvent = await this.signEvent(resolvedEvent);
+
 					this.eventRepository.create(
-						resolvedEvent.event as any /* TODO: fix this with type unifi */,
+						signedEvent.event as any,
 						resolvedEvent.eventId,
-						undefined,
+						'',
 					);
 
 					continue;
@@ -454,7 +551,7 @@ export class StateService {
 				.toArray();
 
 			const publicRooms = eventsCollection.find({
-				_id: {
+				eventId: {
 					$in: publicRoomsWithNames.map(
 						(stateMapping) => stateMapping.delta.eventId,
 					),
@@ -469,12 +566,14 @@ export class StateService {
 				.toArray();
 		}
 
-		const events = eventsCollection.find({
-			_id: { $in: eventsToFetch },
-		});
+		// TODO: i know thisd is overcomplicated
+		//but writing this comment while not remembering what exactkly it does while not wanting to get my brain to do it either
 
-		const nonPublicRooms = await events
-			.filter((event: any) => event.event.content.join_rule !== 'public')
+		const nonPublicRooms = await eventsCollection
+			.find({
+				eventId: { $in: eventsToFetch },
+				'event.content.join_rule': { $ne: 'public' },
+			})
 			.toArray();
 
 		// since no join_rule == public
@@ -492,7 +591,7 @@ export class StateService {
 			.toArray();
 
 		const publicRoomsWithNamesEvents = eventsCollection.find({
-			_id: {
+			eventId: {
 				$in: publicRoomsWithNames.map(
 					(stateMapping) => stateMapping.delta.eventId,
 				),
@@ -505,5 +604,29 @@ export class StateService {
 				name: (event.event.content?.name as string) ?? '',
 			}))
 			.toArray();
+	}
+
+	async getMembersOfRoom(roomId: string) {
+		const stateCollection = await this.stateRepository.getCollection();
+
+		const stateMappings = await stateCollection
+			.find({ roomId, 'delta.identifier': /^m\.room\.member:/ })
+			.toArray();
+
+		const events = await this.eventRepository.findByIds(
+			stateMappings.map((stateMapping) => stateMapping.delta.eventId),
+		);
+
+		const members = events
+			.filter((event) => event.event.content?.membership === 'join')
+			.map((event) => event.event.state_key as string);
+
+		return members;
+	}
+
+	async getServersInRoom(roomId: string) {
+		return this.getMembersOfRoom(roomId).then((members) =>
+			members.map((member) => member.split(':').pop()!),
+		);
 	}
 }

--- a/packages/room/src/authorizartion-rules/rules.ts
+++ b/packages/room/src/authorizartion-rules/rules.ts
@@ -747,7 +747,7 @@ export async function checkEventAuthWithState(
 		);
 	}
 
-	if (event.isCanonicalAliasEvent()) {
+	if (event.isAliasEvent()) {
 		return isRoomAliasAllowed(event);
 	}
 

--- a/packages/room/src/manager/event-wrapper.ts
+++ b/packages/room/src/manager/event-wrapper.ts
@@ -12,6 +12,7 @@ import {
 	PduType,
 	Pdu,
 	PduContent,
+	PduTypeRoomAliases,
 } from '../types/v3-11';
 import crypto from 'node:crypto';
 import {
@@ -166,6 +167,10 @@ export abstract class PersistentEventBase<T extends RoomVersion = '11'> {
 
 	isCanonicalAliasEvent() {
 		return this.isState() && this.type === PduTypeRoomCanonicalAlias;
+	}
+
+	isAliasEvent() {
+		return this.isState() && this.type === PduTypeRoomAliases;
 	}
 
 	getMembership() {

--- a/packages/room/src/types/v3-11.ts
+++ b/packages/room/src/types/v3-11.ts
@@ -445,6 +445,12 @@ export function generatePduSchemaForBase<T>(base: T) {
 			type: z.literal(PduTypeRoomName),
 			content: PduRoomNameEventContentSchema,
 		}),
+
+		z.object({
+			...base,
+			type: z.literal(PduTypeRoomAliases),
+			content: PduCanonicalAliasEventContentSchema,
+		}),
 	]);
 }
 


### PR DESCRIPTION
With this **most** state change actions will be

```ts
const event = PersistentEventFactory.newTypeEvent(...params); // add method if doesn't exist already
await stateService.addAuthEvents(event);
await stateService.addPrevEvents(event);
await stateService.signEvent(event);
await stateService.persistEvent(event);
if (event.rejected) {
    throw new Error(event.rejectedReason);
}
void federationService.sendEventToAllServers(event);
```

Messages are exception, there is a pr i will rebase after this. Removals are slightly different.