### PR TITLE
feat: adds threads messaging

### DIFF
--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -350,9 +350,17 @@ export class StagingAreaService {
 						room_id: event.roomId,
 						sender: event.event.sender,
 						origin_server_ts: event.event.origin_server_ts,
-						content: {
-							body: event.event.content?.body as string,
-							msgtype: event.event.content?.msgtype as string,
+						content: event.event.content as {
+							body: string;
+							msgtype: string;
+							'm.relates_to'?: {
+								rel_type: string;
+								event_id: string;
+								is_falling_back?: boolean;
+								'm.in_reply_to'?: {
+									event_id: string;
+								};
+							};
 						},
 					});
 					break;

--- a/packages/room/src/manager/factory.ts
+++ b/packages/room/src/manager/factory.ts
@@ -401,4 +401,47 @@ export class PersistentEventFactory {
 
 		return PersistentEventFactory.createFromRawEvent(eventPartial, roomVersion);
 	}
+
+	static newThreadMessageEvent(
+		roomId: string,
+		sender: string,
+		text: string,
+		threadRootEventId: string,
+		latestThreadEventId?: string,
+		roomVersion: RoomVersion = PersistentEventFactory.defaultRoomVersion,
+	) {
+		if (!PersistentEventFactory.isSupportedRoomVersion(roomVersion)) {
+			throw new Error(`Room version ${roomVersion} is not supported`);
+		}
+
+		const eventPartial: Omit<
+			PduForType<typeof PduTypeRoomMessage>,
+			'signatures' | 'hashes'
+		> = {
+			type: PduTypeRoomMessage,
+			content: {
+				msgtype: 'm.text' as const,
+				body: text,
+				'm.relates_to': {
+					rel_type: 'm.thread' as const,
+					event_id: threadRootEventId,
+					is_falling_back: true,
+					...(latestThreadEventId && {
+						'm.in_reply_to': {
+							event_id: latestThreadEventId,
+						},
+					}),
+				},
+			},
+			sender: sender,
+			origin: sender.split(':').pop(),
+			origin_server_ts: Date.now(),
+			room_id: roomId,
+			prev_events: [],
+			auth_events: [],
+			depth: 0,
+		};
+
+		return PersistentEventFactory.createFromRawEvent(eventPartial, roomVersion);
+	}
 }

--- a/packages/room/src/types/v3-11.ts
+++ b/packages/room/src/types/v3-11.ts
@@ -339,6 +339,24 @@ export const PduMessageEventContentSchema = z.object({
 	body: z.string().describe('The body of the message.'),
 	// TODO: add more types
 	msgtype: z.enum(['m.text', 'm.image']).describe('The type of the message.'),
+	// Optional thread relation for thread messages
+	'm.relates_to': z
+		.object({
+			rel_type: z.literal('m.thread').describe('Thread relation type'),
+			event_id: z.string().describe('The ID of the thread root event'),
+			is_falling_back: z
+				.boolean()
+				.optional()
+				.describe('Whether this is a fallback for older clients'),
+			'm.in_reply_to': z
+				.object({
+					event_id: z
+						.string()
+						.describe('The ID of the latest event in the thread for fallback'),
+				})
+				.optional(),
+		})
+		.optional(),
 });
 
 export type PduMessageEventContent = z.infer<


### PR DESCRIPTION
This PR adds full support for Matrix threads as defined in MSC3440, as per [FDR-93](https://rocketchat.atlassian.net/browse/FDR-93) and [FDR-100](https://rocketchat.atlassian.net/browse/FDR-100).

We’ve implemented `sendThreadMessage` in `MessageService` and updated the content schema to support `m.relates_to` for threaded relationships. This includes support for:
- `rel_type: "m.thread"` to identify thread messages
- `event_id` pointing to the thread root
- `is_falling_back` for client compatibility
- `m.in_reply_to` for message ordering

Thread messages now follow this structure:

```ts
{
  "m.relates_to": {
    "rel_type": "m.thread",
    "event_id": "$thread_root",
    "is_falling_back": true,
    "m.in_reply_to": {
      "event_id": "$latest_thread_event"
    }
  }
}
```

With this, we now support:
- sending and continuing threads
- correct message ordering within threads
- fallback for clients that don’t support threads
- federation of thread messages
- reactions and deletions (redactions) within threads

This implementation is compatible with Matrix protocol v1.3+ and MSC3440.

[FDR-93]: https://rocketchat.atlassian.net/browse/FDR-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FDR-100]: https://rocketchat.atlassian.net/browse/FDR-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ