### PR TITLE
refactor: removes unused config methods and creates more unified other ones

### DIFF
--- a/packages/federation-sdk/src/services/config.service.ts
+++ b/packages/federation-sdk/src/services/config.service.ts
@@ -1,12 +1,9 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import {
 	createLogger,
 	generateKeyPairsFromString,
 	getKeyPair,
 	toUnpaddedBase64,
 } from '@hs/core';
-import * as dotenv from 'dotenv';
 
 import { z } from 'zod';
 
@@ -26,7 +23,7 @@ export interface AppConfig {
 		name: string;
 		poolSize: number;
 	};
-	media?: {
+	media: {
 		maxFileSize: number;
 		allowedMimeTypes: string[];
 		enableThumbnails: boolean;
@@ -54,26 +51,24 @@ export const AppConfigSchema = z.object({
 		name: z.string().min(1, 'Database name is required'),
 		poolSize: z.number().int().min(1, 'Pool size must be at least 1'),
 	}),
-	media: z
-		.object({
-			maxFileSize: z
+	media: z.object({
+		maxFileSize: z
+			.number()
+			.int()
+			.min(1, 'Max file size must be at least 1 byte'),
+		allowedMimeTypes: z.array(z.string()),
+		enableThumbnails: z.boolean(),
+		rateLimits: z.object({
+			uploadPerMinute: z
 				.number()
 				.int()
-				.min(1, 'Max file size must be at least 1 byte'),
-			allowedMimeTypes: z.array(z.string()),
-			enableThumbnails: z.boolean(),
-			rateLimits: z.object({
-				uploadPerMinute: z
-					.number()
-					.int()
-					.min(1, 'Upload rate limit must be at least 1'),
-				downloadPerMinute: z
-					.number()
-					.int()
-					.min(1, 'Download rate limit must be at least 1'),
-			}),
-		})
-		.optional(),
+				.min(1, 'Upload rate limit must be at least 1'),
+			downloadPerMinute: z
+				.number()
+				.int()
+				.min(1, 'Download rate limit must be at least 1'),
+		}),
+	}),
 });
 
 export class ConfigService {
@@ -81,12 +76,8 @@ export class ConfigService {
 	private logger = createLogger('ConfigService');
 
 	constructor(values: AppConfig) {
-		// Load config from environment if not provided
-		const configValues = values || this.initializeConfig();
-
 		try {
-			const validatedConfig = AppConfigSchema.parse(configValues);
-			this.config = validatedConfig;
+			this.config = AppConfigSchema.parse(values);
 		} catch (error) {
 			if (error instanceof z.ZodError) {
 				this.logger.error('Configuration validation failed:', error.errors);
@@ -98,52 +89,20 @@ export class ConfigService {
 		}
 	}
 
-	getConfig(): AppConfig {
-		return this.config;
+	get serverName(): string {
+		return this.config.serverName;
 	}
 
-	getServerConfig(): { name: string; port: number; version: string } {
-		return {
-			name: this.config.serverName,
-			port: this.config.port,
-			version: this.config.version,
-		};
+	get version(): string {
+		return this.config.version;
 	}
 
 	getDatabaseConfig(): AppConfig['database'] {
 		return this.config.database;
 	}
 
-	getMatrixConfig(): {
-		serverName: string;
-		domain: string;
-		keyRefreshInterval: number;
-	} {
-		return {
-			serverName: this.config.serverName,
-			domain: this.config.matrixDomain,
-			keyRefreshInterval: this.config.keyRefreshInterval,
-		};
-	}
-
-	getMediaConfig(): {
-		maxFileSize: number;
-		allowedMimeTypes: string[];
-		enableThumbnails: boolean;
-		rateLimits: {
-			uploadPerMinute: number;
-			downloadPerMinute: number;
-		};
-	} {
-		return this.config.media || this.getDefaultMediaConfig();
-	}
-
-	get serverName(): string {
-		return this.config.serverName;
-	}
-
-	get timeout(): number {
-		return this.config.timeout || 30000;
+	getMediaConfig(): AppConfig['media'] {
+		return this.config.media;
 	}
 
 	async getSigningKey() {
@@ -169,67 +128,6 @@ export class ConfigService {
 		return toUnpaddedBase64(signingKeys[0].privateKey);
 	}
 
-	async reconstructSigningKey(keyData: string) {
-		this.logger.info('Reconstructing signing key from settings data');
-
-		try {
-			const signingKey = await generateKeyPairsFromString(keyData);
-			this.logger.info('Successfully reconstructed signing key from settings');
-			return signingKey;
-		} catch (error: unknown) {
-			const errorMessage =
-				error instanceof Error ? error.message : 'Unknown error';
-			this.logger.error(`Failed to reconstruct signing key: ${errorMessage}`);
-			throw error;
-		}
-	}
-
-	private loadEnvFiles(): void {
-		const nodeEnv = process.env.NODE_ENV || 'development';
-
-		const defaultEnvPath = path.resolve(process.cwd(), '.env');
-		if (fs.existsSync(defaultEnvPath)) {
-			dotenv.config({ path: defaultEnvPath });
-			this.logger.info('Loaded configuration from .env');
-		}
-
-		const envSpecificPath = path.resolve(process.cwd(), `.env.${nodeEnv}`);
-		if (fs.existsSync(envSpecificPath)) {
-			dotenv.config({ path: envSpecificPath });
-			this.logger.info(`Loaded configuration from .env.${nodeEnv}`);
-		}
-
-		const localEnvPath = path.resolve(process.cwd(), '.env.local');
-		if (fs.existsSync(localEnvPath)) {
-			dotenv.config({ path: localEnvPath });
-			this.logger.info('Loaded configuration from .env.local');
-		}
-	}
-
-	private mergeConfigs(
-		baseConfig: AppConfig,
-		newConfig: Partial<AppConfig>,
-	): AppConfig {
-		return {
-			...baseConfig,
-			...newConfig,
-			database: { ...baseConfig.database, ...newConfig.database },
-			media: newConfig.media
-				? {
-						...baseConfig.media,
-						...newConfig.media,
-						rateLimits: newConfig.media.rateLimits
-							? {
-									...baseConfig.media?.rateLimits,
-									...newConfig.media.rateLimits,
-								}
-							: baseConfig.media?.rateLimits ||
-								this.getDefaultMediaConfig().rateLimits,
-					}
-				: baseConfig.media,
-		};
-	}
-
 	async loadSigningKey() {
 		try {
 			const signingKeyPath = `${CONFIG_FOLDER}/${this.config.serverName}.signing.key`;
@@ -245,83 +143,5 @@ export class ConfigService {
 			this.logger.error(`Failed to load signing key: ${errorMessage}`);
 			throw error;
 		}
-	}
-
-	private initializeConfig(): AppConfig {
-		return {
-			serverName: process.env.SERVER_NAME || 'rc1',
-			port: this.getNumberFromEnv('SERVER_PORT', 8080),
-			version: process.env.SERVER_VERSION || '1.0',
-			database: {
-				uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/matrix',
-				name: process.env.DATABASE_NAME || 'matrix',
-				poolSize: this.getNumberFromEnv('DATABASE_POOL_SIZE', 10),
-			},
-			matrixDomain: process.env.MATRIX_DOMAIN || 'rc1',
-			keyRefreshInterval: this.getNumberFromEnv(
-				'MATRIX_KEY_REFRESH_INTERVAL',
-				60,
-			),
-			signingKeyPath: process.env.CONFIG_FOLDER || './rc1.signing.key',
-			media: {
-				maxFileSize: this.getNumberFromEnv(
-					'MEDIA_MAX_FILE_SIZE',
-					100 * 1024 * 1024,
-				), // 100MB
-				allowedMimeTypes:
-					process.env.MEDIA_ALLOWED_MIME_TYPES?.split(',') || [],
-				enableThumbnails: process.env.MEDIA_ENABLE_THUMBNAILS === 'true',
-				rateLimits: {
-					uploadPerMinute: this.getNumberFromEnv('MEDIA_UPLOAD_RATE_LIMIT', 10),
-					downloadPerMinute: this.getNumberFromEnv(
-						'MEDIA_DOWNLOAD_RATE_LIMIT',
-						60,
-					),
-				},
-			},
-		};
-	}
-
-	private getNumberFromEnv(key: string, defaultValue: number): number {
-		const envValue = process.env[key];
-		return envValue ? Number.parseInt(envValue) : defaultValue;
-	}
-
-	private getDefaultMediaConfig(): {
-		maxFileSize: number;
-		allowedMimeTypes: string[];
-		enableThumbnails: boolean;
-		rateLimits: {
-			uploadPerMinute: number;
-			downloadPerMinute: number;
-		};
-	} {
-		return {
-			maxFileSize: 100 * 1024 * 1024, // 100MB
-			allowedMimeTypes: [
-				'image/jpeg',
-				'image/png',
-				'image/gif',
-				'image/webp',
-				'text/plain',
-				'application/pdf',
-				'video/mp4',
-				'audio/mpeg',
-				'audio/ogg',
-			],
-			enableThumbnails: true,
-			rateLimits: {
-				uploadPerMinute: 10,
-				downloadPerMinute: 60,
-			},
-		};
-	}
-
-	getServerName(): string {
-		return this.config.serverName;
-	}
-
-	isDebugEnabled(): boolean {
-		return process.env.DEBUG === 'true';
 	}
 }

--- a/packages/federation-sdk/src/services/edu.service.ts
+++ b/packages/federation-sdk/src/services/edu.service.ts
@@ -24,7 +24,7 @@ export class EduService {
 		typing: boolean,
 	): Promise<void> {
 		try {
-			const origin = this.configService.getServerName();
+			const origin = this.configService.serverName;
 			const typingEDU = createTypingEDU(roomId, userId, typing, origin);
 
 			this.logger.debug(
@@ -52,7 +52,7 @@ export class EduService {
 		roomIds: string[],
 	): Promise<void> {
 		try {
-			const origin = this.configService.getServerName();
+			const origin = this.configService.serverName;
 			const presenceEDU = createPresenceEDU(presenceUpdates, origin);
 
 			this.logger.debug(

--- a/packages/federation-sdk/src/services/event-fetcher.service.ts
+++ b/packages/federation-sdk/src/services/event-fetcher.service.ts
@@ -137,7 +137,7 @@ export class EventFetcherService {
 			const chunks = this.chunkArray(eventIds, 10);
 
 			for (const chunk of chunks) {
-				if (targetServerName === this.configService.getServerName()) {
+				if (targetServerName === this.configService.serverName) {
 					this.logger.info(`Skipping request to self: ${targetServerName}`);
 					return [];
 				}

--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -509,7 +509,7 @@ export class EventService {
 				(origin, key) =>
 					getPublicKeyFromRemoteServer(
 						origin,
-						this.configService.getServerConfig().name,
+						this.configService.serverName,
 						key,
 					),
 				(origin, keyId, publicKey) =>

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -72,7 +72,7 @@ export class InviteService {
 		}
 
 		// if user invited belongs to our server
-		if (invitedServer === this.configService.getServerName()) {
+		if (invitedServer === this.configService.serverName) {
 			await stateService.persistStateEvent(inviteEvent);
 
 			if (inviteEvent.rejected) {
@@ -142,7 +142,7 @@ export class InviteService {
 
 		await this.stateService.signEvent(inviteEvent);
 
-		if (residentServer === this.configService.getServerName()) {
+		if (residentServer === this.configService.serverName) {
 			// we are the host of the server
 
 			// attempt to persist the invite event as we already have the state

--- a/packages/federation-sdk/src/services/media.service.ts
+++ b/packages/federation-sdk/src/services/media.service.ts
@@ -15,7 +15,7 @@ export class MediaService {
 	) {}
 
 	generateMXCUri(mediaId?: string): string {
-		const serverName = this.configService.getServerConfig().name;
+		const serverName = this.configService.serverName;
 		const id = mediaId || crypto.randomBytes(16).toString('hex');
 		return `mxc://${serverName}/${id}`;
 	}
@@ -52,7 +52,7 @@ export class MediaService {
 			if (decoded.includes(':')) {
 				userId = `@${decoded}`;
 			} else {
-				userId = `@${decoded}:${this.configService.getServerConfig().name}`;
+				userId = `@${decoded}:${this.configService.serverName}`;
 			}
 
 			if (userId.match(/^@[^:]+:[^:]+$/)) {
@@ -69,7 +69,7 @@ export class MediaService {
 		authHeader: string | null,
 	): Promise<Response | { errcode: string; error: string }> {
 		const { userId, isAuthenticated } = this.extractUserFromToken(authHeader);
-		const ourServerName = this.configService.getServerConfig().name;
+		const ourServerName = this.configService.serverName;
 
 		this.logger.info('Media download request', {
 			serverName,
@@ -110,7 +110,7 @@ export class MediaService {
 			const response = await fetch(remoteUrl, {
 				method: 'GET',
 				headers: {
-					'User-Agent': `RocketChat-Matrix-Bridge/${this.configService.getServerConfig().version}`,
+					'User-Agent': `RocketChat-Matrix-Bridge/${this.configService.version}`,
 				},
 				signal: AbortSignal.timeout(30000),
 			});
@@ -182,7 +182,7 @@ export class MediaService {
 			};
 		}
 
-		const ourServerName = this.configService.getServerConfig().name;
+		const ourServerName = this.configService.serverName;
 		if (serverName === ourServerName) {
 			return {
 				errcode: 'M_UNRECOGNIZED',

--- a/packages/federation-sdk/src/services/send-join.service.ts
+++ b/packages/federation-sdk/src/services/send-join.service.ts
@@ -57,7 +57,7 @@ export class SendJoinService {
 
 		const configService = this.configService;
 
-		const origin = configService.getServerConfig().name;
+		const origin = configService.serverName;
 
 		const authChain = [];
 

--- a/packages/federation-sdk/src/services/server.service.ts
+++ b/packages/federation-sdk/src/services/server.service.ts
@@ -28,7 +28,6 @@ export class ServerService {
 	}
 
 	async getSignedServerKey() {
-		const config = this.configService.getConfig();
 		const signingKeys = await this.configService.getSigningKey();
 
 		const keys = Object.fromEntries(
@@ -42,7 +41,7 @@ export class ServerService {
 
 		const baseResponse = {
 			old_verify_keys: {},
-			server_name: config.serverName,
+			server_name: this.configService.serverName,
 			signatures: {},
 			valid_until_ts: new Date().getTime() + 60 * 60 * 24 * 1000, // 1 day
 			verify_keys: keys,
@@ -50,7 +49,11 @@ export class ServerService {
 
 		let signedResponse = baseResponse;
 		for (const key of signingKeys) {
-			signedResponse = await signJson(signedResponse, key, config.serverName);
+			signedResponse = await signJson(
+				signedResponse,
+				key,
+				this.configService.serverName,
+			);
 		}
 
 		return signedResponse;

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -355,7 +355,7 @@ export class StateService {
 	public async signEvent(event: PersistentEventBase) {
 		const signingKey = await this.configService.getSigningKey();
 
-		const origin = this.configService.getServerName();
+		const origin = this.configService.serverName;
 
 		const result = await signEvent(
 			// Before signing the event, the content hash of the event is calculated as described below. The hash is encoded using Unpadded Base64 and stored in the event object, in a hashes object, under a sha256 key.

--- a/packages/federation-sdk/src/services/well-known.service.ts
+++ b/packages/federation-sdk/src/services/well-known.service.ts
@@ -7,7 +7,7 @@ export class WellKnownService {
 
 	getWellKnownHostData() {
 		return {
-			'm.server': `${this.configService.getServerConfig().name}:443`,
+			'm.server': `${this.configService.serverName}:443`,
 		};
 	}
 }

--- a/packages/homeserver/src/controllers/federation/versions.controller.ts
+++ b/packages/homeserver/src/controllers/federation/versions.controller.ts
@@ -8,11 +8,10 @@ export const versionsPlugin = (app: Elysia) => {
 	return app.get(
 		'/_matrix/federation/v1/version',
 		() => {
-			const config = configService.getServerConfig();
 			return {
 				server: {
-					name: config.name,
-					version: config.version,
+					name: configService.serverName,
+					version: configService.version,
 				},
 			};
 		},

--- a/packages/homeserver/src/homeserver.module.ts
+++ b/packages/homeserver/src/homeserver.module.ts
@@ -72,12 +72,14 @@ export async function setup(options?: HomeserverSetupOptions) {
 			],
 			enableThumbnails: process.env.MEDIA_ENABLE_THUMBNAILS === 'true' || true,
 			rateLimits: {
-				uploadPerMinute:
-					Number.parseInt(process.env.MEDIA_UPLOAD_RATE_LIMIT || '10', 10) ||
+				uploadPerMinute: Number.parseInt(
+					process.env.MEDIA_UPLOAD_RATE_LIMIT || '10',
 					10,
-				downloadPerMinute:
-					Number.parseInt(process.env.MEDIA_DOWNLOAD_RATE_LIMIT || '60', 10) ||
-					60,
+				),
+				downloadPerMinute: Number.parseInt(
+					process.env.MEDIA_DOWNLOAD_RATE_LIMIT || '60',
+					10,
+				),
 			},
 		},
 	});

--- a/packages/homeserver/src/homeserver.module.ts
+++ b/packages/homeserver/src/homeserver.module.ts
@@ -55,6 +55,31 @@ export async function setup(options?: HomeserverSetupOptions) {
 		),
 		signingKeyPath: process.env.CONFIG_FOLDER || './rc1.signing.key',
 		version: process.env.SERVER_VERSION || '1.0',
+		media: {
+			maxFileSize: process.env.MEDIA_MAX_FILE_SIZE
+				? Number.parseInt(process.env.MEDIA_MAX_FILE_SIZE, 10) * 1024 * 1024
+				: 100 * 1024 * 1024,
+			allowedMimeTypes: process.env.MEDIA_ALLOWED_MIME_TYPES?.split(',') || [
+				'image/jpeg',
+				'image/png',
+				'image/gif',
+				'image/webp',
+				'text/plain',
+				'application/pdf',
+				'video/mp4',
+				'audio/mpeg',
+				'audio/ogg',
+			],
+			enableThumbnails: process.env.MEDIA_ENABLE_THUMBNAILS === 'true' || true,
+			rateLimits: {
+				uploadPerMinute:
+					Number.parseInt(process.env.MEDIA_UPLOAD_RATE_LIMIT || '10', 10) ||
+					10,
+				downloadPerMinute:
+					Number.parseInt(process.env.MEDIA_DOWNLOAD_RATE_LIMIT || '60', 10) ||
+					60,
+			},
+		},
 	});
 
 	const containerOptions: FederationContainerOptions = {


### PR DESCRIPTION
This PR makes media config environment variables mandatory and injects them during container initialization, instead of relying on defaults from the config service.

It also simplifies some getters by returning only the required fields (mainly serverName and version) instead of entire objects.

Works along with https://github.com/RocketChat/Rocket.Chat/pull/36862.