### PR TITLE
refactor: removes StagedEvent type

### DIFF
--- a/packages/core/src/models/event.model.ts
+++ b/packages/core/src/models/event.model.ts
@@ -1,12 +1,10 @@
-import { PduForType } from '@hs/room';
+import { Pdu } from '@hs/room';
 import type { EventBase as CoreEventBase } from '../events/eventBase';
 
 // TODO: use room package
 
 // TODO: Merge with StagedEvent from event.service.ts
-export interface EventStore<
-	E extends CoreEventBase | PduForType = CoreEventBase,
-> {
+export interface EventStore<E extends CoreEventBase | Pdu = CoreEventBase> {
 	_id: string;
 	event: E;
 

--- a/packages/federation-sdk/src/listeners/missing-event.listener.ts
+++ b/packages/federation-sdk/src/listeners/missing-event.listener.ts
@@ -6,7 +6,6 @@ import type { MissingEventType } from '../queues/missing-event.queue';
 import { MissingEventsQueue } from '../queues/missing-event.queue';
 import { EventFetcherService } from '../services/event-fetcher.service';
 import { EventService } from '../services/event.service';
-import type { StagedEvent } from '../services/event.service';
 import { StagingAreaService } from '../services/staging-area.service';
 
 @singleton()
@@ -136,7 +135,6 @@ export class MissingEventListener {
 				await this.eventService.storeEventAsStaged({
 					_id: eventId,
 					event: event,
-					origin: event.origin || origin,
 					missing_dependencies: missing,
 				});
 


### PR DESCRIPTION
- Removes `StagedEvent` in order to use `EventStore`.

Closes https://github.com/RocketChat/homeserver/issues/134.