### PR TITLE
chore: improves DI injection by removing register tokens

### DIFF
--- a/packages/federation-sdk/src/listeners/missing-event.listener.ts
+++ b/packages/federation-sdk/src/listeners/missing-event.listener.ts
@@ -1,6 +1,5 @@
 import type { EventBase, EventStore } from '@hs/core';
 import { createLogger } from '@hs/core';
-import { inject } from 'tsyringe';
 import { singleton } from 'tsyringe';
 import type { MissingEventType } from '../queues/missing-event.queue';
 import { MissingEventsQueue } from '../queues/missing-event.queue';
@@ -14,9 +13,7 @@ export class MissingEventListener {
 	private readonly logger = createLogger('MissingEventListener');
 
 	constructor(
-		@inject('MissingEventsQueue')
 		private readonly missingEventsQueue: MissingEventsQueue,
-		@inject('StagingAreaService')
 		private readonly stagingAreaService: StagingAreaService,
 		private readonly eventService: EventService,
 		private readonly eventFetcherService: EventFetcherService,

--- a/packages/federation-sdk/src/listeners/staging-area.listener.ts
+++ b/packages/federation-sdk/src/listeners/staging-area.listener.ts
@@ -1,17 +1,15 @@
 import { createLogger } from '@hs/core';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import type { StagingAreaEventType } from '../queues/staging-area.queue';
 import { StagingAreaQueue } from '../queues/staging-area.queue';
-import type { StagingAreaService } from '../services/staging-area.service';
+import { StagingAreaService } from '../services/staging-area.service';
 
 @singleton()
 export class StagingAreaListener {
 	private readonly logger = createLogger('StagingAreaListener');
 
 	constructor(
-		@inject('StagingAreaQueue')
 		private readonly stagingAreaQueue: StagingAreaQueue,
-		@inject('StagingAreaService')
 		private readonly stagingAreaService: StagingAreaService,
 	) {
 		this.stagingAreaQueue.registerHandler(this.handleQueueItem.bind(this));

--- a/packages/federation-sdk/src/repositories/event.repository.ts
+++ b/packages/federation-sdk/src/repositories/event.repository.ts
@@ -161,13 +161,6 @@ export class EventRepository {
 		return this.collection.find({ staged: true }).toArray();
 	}
 
-	async findOldestStaged(roomId: string): Promise<EventStore | null> {
-		return this.collection.findOne(
-			{ staged: true, 'event.room_id': roomId },
-			{ sort: { 'event.origin_server_ts': 1 } },
-		);
-	}
-
 	public async findPowerLevelsEventByRoomId(
 		roomId: string,
 	): Promise<EventStore | null> {

--- a/packages/federation-sdk/src/services/database-connection.service.ts
+++ b/packages/federation-sdk/src/services/database-connection.service.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@hs/core';
 import { Db, MongoClient, type MongoClientOptions } from 'mongodb';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { ConfigService } from './config.service';
 
 @singleton()
@@ -10,9 +10,7 @@ export class DatabaseConnectionService {
 	private connectionPromise: Promise<void> | null = null;
 	private readonly logger = createLogger('DatabaseConnectionService');
 
-	constructor(
-		@inject('ConfigService') private readonly configService: ConfigService,
-	) {
+	constructor(private readonly configService: ConfigService) {
 		this.connect().catch((err) =>
 			this.logger.error(`Initial database connection failed: ${err.message}`),
 		);

--- a/packages/federation-sdk/src/services/edu.service.ts
+++ b/packages/federation-sdk/src/services/edu.service.ts
@@ -1,7 +1,7 @@
 import type { PresenceUpdate } from '@hs/core';
 import { createPresenceEDU, createTypingEDU } from '@hs/core';
 import { createLogger } from '@hs/core';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
 import { FederationService } from './federation.service';
@@ -12,10 +12,10 @@ export class EduService {
 	private readonly logger = createLogger('EduService');
 
 	constructor(
-		@inject('ConfigService') private readonly configService: ConfigService,
+		private readonly configService: ConfigService,
 		private readonly federationService: FederationService,
 		private readonly eventEmitterService: EventEmitterService,
-		@inject('StateService') private readonly stateService: StateService,
+		private readonly stateService: StateService,
 	) {}
 
 	async sendTypingNotification(

--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -20,16 +20,16 @@ import { pruneEventDict } from '@hs/core';
 import { checkSignAndHashes } from '@hs/core';
 import { createLogger } from '@hs/core';
 import { type PduType, PersistentEventFactory } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import type { z } from 'zod';
-import type { StagingAreaQueue } from '../queues/staging-area.queue';
-import type { EventRepository } from '../repositories/event.repository';
-import type { KeyRepository } from '../repositories/key.repository';
-import type { RoomRepository } from '../repositories/room.repository';
+import { StagingAreaQueue } from '../queues/staging-area.queue';
+import { EventRepository } from '../repositories/event.repository';
+import { KeyRepository } from '../repositories/key.repository';
+import { RoomRepository } from '../repositories/room.repository';
 import { eventSchemas } from '../utils/event-schemas';
-import type { ConfigService } from './config.service';
+import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
-import type { StateService } from './state.service';
+import { StateService } from './state.service';
 
 type ValidationResult = {
 	eventId: string;
@@ -69,15 +69,14 @@ export class EventService {
 	private currentTransactions = new Set<string>();
 
 	constructor(
-		@inject('EventRepository')
 		private readonly eventRepository: EventRepository,
-		@inject('RoomRepository') private readonly roomRepository: RoomRepository,
-		@inject('KeyRepository') private readonly keyRepository: KeyRepository,
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('StagingAreaQueue')
+		private readonly roomRepository: RoomRepository,
+		private readonly keyRepository: KeyRepository,
+		private readonly configService: ConfigService,
+
 		private readonly stagingAreaQueue: StagingAreaQueue,
-		@inject('StateService') private readonly stateService: StateService,
-		@inject(EventEmitterService)
+		private readonly stateService: StateService,
+
 		private readonly eventEmitterService: EventEmitterService,
 	) {}
 

--- a/packages/federation-sdk/src/services/federation.service.ts
+++ b/packages/federation-sdk/src/services/federation.service.ts
@@ -3,7 +3,7 @@ import type { BaseEDU } from '@hs/core';
 import type { ProtocolVersionKey } from '@hs/core';
 import { createLogger } from '@hs/core';
 import { PersistentEventBase } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import {
 	FederationEndpoints,
 	type MakeJoinResponse,
@@ -22,10 +22,10 @@ export class FederationService {
 	private readonly logger = createLogger('FederationService');
 
 	constructor(
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('FederationRequestService')
+		private readonly configService: ConfigService,
+
 		private readonly requestService: FederationRequestService,
-		@inject('SignatureVerificationService')
+
 		private readonly signatureService: SignatureVerificationService,
 		private readonly stateService: StateService,
 	) {}

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -1,9 +1,10 @@
 import { EventBase, HttpException, HttpStatus } from '@hs/core';
-import { ConfigService, FederationService } from '@hs/federation-sdk';
 import { PersistentEventFactory, RoomVersion } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { createLogger } from '../utils/logger';
+import { ConfigService } from './config.service';
 import { EventService } from './event.service';
+import { FederationService } from './federation.service';
 import { StateService } from './state.service';
 // TODO: Have better (detailed/specific) event input type
 export type ProcessInviteEvent = {
@@ -17,11 +18,11 @@ export class InviteService {
 	private readonly logger = createLogger('InviteService');
 
 	constructor(
-		@inject('EventService') private readonly eventService: EventService,
-		@inject('FederationService')
+		private readonly eventService: EventService,
+
 		private readonly federationService: FederationService,
-		@inject('StateService') private readonly stateService: StateService,
-		@inject('ConfigService') private readonly configService: ConfigService,
+		private readonly stateService: StateService,
+		private readonly configService: ConfigService,
 	) {}
 
 	/**

--- a/packages/federation-sdk/src/services/media.service.ts
+++ b/packages/federation-sdk/src/services/media.service.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { createLogger } from '@hs/core';
-import { inject, singleton } from 'tsyringe';
-import type { ConfigService } from './config.service';
+import { singleton } from 'tsyringe';
+import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
 
 @singleton()
@@ -9,8 +9,8 @@ export class MediaService {
 	private readonly logger = createLogger('MediaService');
 
 	constructor(
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('EventEmitterService')
+		private readonly configService: ConfigService,
+
 		private readonly eventEmitterService: EventEmitterService,
 	) {}
 

--- a/packages/federation-sdk/src/services/message.service.ts
+++ b/packages/federation-sdk/src/services/message.service.ts
@@ -18,27 +18,26 @@ import {
 	PersistentEventFactory,
 	type RoomVersion,
 } from '@hs/room';
-import { inject } from 'tsyringe';
 import { singleton } from 'tsyringe';
-import type { EventRepository } from '../repositories/event.repository';
-import type { ConfigService } from './config.service';
+import { EventRepository } from '../repositories/event.repository';
+import { ConfigService } from './config.service';
 import { EventService } from './event.service';
 import { FederationService } from './federation.service';
-import type { RoomService } from './room.service';
-import type { StateService } from './state.service';
+import { RoomService } from './room.service';
+import { StateService } from './state.service';
 
 @singleton()
 export class MessageService {
 	private readonly logger = createLogger('MessageService');
 
 	constructor(
-		@inject('EventService') private readonly eventService: EventService,
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('FederationService')
+		private readonly eventService: EventService,
+		private readonly configService: ConfigService,
+
 		private readonly federationService: FederationService,
-		@inject('RoomService') private readonly roomService: RoomService,
-		@inject('StateService') private readonly stateService: StateService,
-		@inject('EventRepository')
+		private readonly roomService: RoomService,
+		private readonly stateService: StateService,
+
 		private readonly eventRepository: EventRepository,
 	) {}
 

--- a/packages/federation-sdk/src/services/profiles.service.ts
+++ b/packages/federation-sdk/src/services/profiles.service.ts
@@ -6,7 +6,7 @@ import { EventService } from './event.service';
 import type { AuthEvents, EventBase, RoomMemberEvent } from '@hs/core';
 import type { EventStore } from '@hs/core';
 import { PersistentEventFactory, RoomVersion } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { EventRepository } from '../repositories/event.repository';
 import { StateService } from './state.service';
 
@@ -15,12 +15,12 @@ export class ProfilesService {
 	private readonly logger = createLogger('ProfilesService');
 
 	constructor(
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('EventService') private readonly eventService: EventService,
+		private readonly configService: ConfigService,
+		private readonly eventService: EventService,
 		// private readonly roomService: RoomService,
-		@inject('EventRepository')
+
 		private readonly eventRepository: EventRepository,
-		@inject('StateService') private readonly stateService: StateService,
+		private readonly stateService: StateService,
 	) {}
 	async queryProfile(userId: string): Promise<{
 		avatar_url: string;

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -12,7 +12,7 @@ import {
 	roomTombstoneEvent,
 	signEvent,
 } from '@hs/core';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { FederationService } from './federation.service';
 
 import { ForbiddenError, HttpException, HttpStatus } from '@hs/core';
@@ -28,7 +28,7 @@ import {
 	RoomVersion,
 } from '@hs/room';
 import { EventRepository } from '../repositories/event.repository';
-import type { RoomRepository } from '../repositories/room.repository';
+import { RoomRepository } from '../repositories/room.repository';
 import { ConfigService } from './config.service';
 import { EventService } from './event.service';
 
@@ -38,14 +38,12 @@ import { StateService } from './state.service';
 @singleton()
 export class RoomService {
 	constructor(
-		@inject('RoomRepository') private readonly roomRepository: RoomRepository,
-		@inject('EventRepository')
+		private readonly roomRepository: RoomRepository,
 		private readonly eventRepository: EventRepository,
-		@inject('EventService') private readonly eventService: EventService,
-		@inject('ConfigService') private readonly configService: ConfigService,
-		@inject('FederationService')
+		private readonly eventService: EventService,
+		private readonly configService: ConfigService,
 		private readonly federationService: FederationService,
-		@inject('StateService') private readonly stateService: StateService,
+		private readonly stateService: StateService,
 		private readonly inviteService: InviteService,
 	) {}
 

--- a/packages/federation-sdk/src/services/send-join.service.ts
+++ b/packages/federation-sdk/src/services/send-join.service.ts
@@ -4,20 +4,20 @@ import {
 	PersistentEventFactory,
 	getAuthChain,
 } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
-import type { EventService } from './event.service';
+import { EventService } from './event.service';
 import { StateService } from './state.service';
 
 @singleton()
 export class SendJoinService {
 	constructor(
-		@inject('EventService') private readonly eventService: EventService,
-		@inject(EventEmitterService)
+		private readonly eventService: EventService,
+
 		private readonly emitterService: EventEmitterService,
-		@inject(StateService) private readonly stateService: StateService,
-		@inject(ConfigService) private readonly configService: ConfigService,
+		private readonly stateService: StateService,
+		private readonly configService: ConfigService,
 	) {}
 
 	async sendJoin(roomId: string, eventId: string, event: RoomMemberEvent) {

--- a/packages/federation-sdk/src/services/server.service.ts
+++ b/packages/federation-sdk/src/services/server.service.ts
@@ -1,14 +1,13 @@
 import { type SigningKey, signJson, toUnpaddedBase64 } from '@hs/core';
-import { inject, singleton } from 'tsyringe';
-import type { ServerRepository } from '../repositories/server.repository';
-import type { ConfigService } from './config.service';
+import { singleton } from 'tsyringe';
+import { ServerRepository } from '../repositories/server.repository';
+import { ConfigService } from './config.service';
 
 @singleton()
 export class ServerService {
 	constructor(
-		@inject('ServerRepository')
 		private readonly serverRepository: ServerRepository,
-		@inject('ConfigService') private configService: ConfigService,
+		private configService: ConfigService,
 	) {}
 
 	async getValidPublicKeyFromLocal(

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -11,7 +11,7 @@ import type { RoomVersion } from '@hs/room';
 import { resolveStateV2Plus } from '@hs/room';
 import type { PduCreateEventContent } from '@hs/room';
 import { checkEventAuthWithState } from '@hs/room';
-import { inject, singleton } from 'tsyringe';
+import { singleton } from 'tsyringe';
 import { EventRepository } from '../repositories/event.repository';
 import { StateRepository } from '../repositories/state.repository';
 import { createLogger } from '../utils/logger';
@@ -30,11 +30,10 @@ type StrippedRoomState = {
 export class StateService {
 	private readonly logger = createLogger('StateService');
 	constructor(
-		@inject('StateRepository')
 		private readonly stateRepository: StateRepository,
-		@inject('EventRepository')
+
 		private readonly eventRepository: EventRepository,
-		@inject('ConfigService') private readonly configService: ConfigService,
+		private readonly configService: ConfigService,
 	) {}
 
 	async getRoomInformation(roomId: string): Promise<PduCreateEventContent> {


### PR DESCRIPTION
Refactored the dependency injection system to use direct class-based registration instead of string tokens.
  - Removed string token registrations from container.ts - services now use direct class references
  - Deleted all @inject decorators that were using string tokens

---

When to use each approach:
  - `register(Class, { useValue })`: When you have a pre-configured instance to inject (like ConfigService with env vars)
  - `registerSingleton(Class)`: For stateful services that need a single instance - most services fall into this category
  - `container.resolve(Class)`: To manually instantiate and trigger constructor side effects - needed for listeners that register handlers

String tokens vs Class tokens:
  - Class tokens: Better type safety, IDE support, and refactoring. Use these by default.
  - String tokens: Only needed for multiple implementations of an interface or when classes aren't available across package boundaries. Eg. registering our MongoDB collections.  `container.register<Collection<EventStore('EventCollection', {...});`