### PR TITLE
fix: state resolution algorithm taking into account wrong events for unconflicted state

### DIFF
--- a/packages/room/src/state_resolution/definitions/algorithm/v2.spec.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.spec.ts
@@ -637,4 +637,34 @@ describe('Definitions', () => {
 
 		expect(diff).toEqual(new Set([dEvent.eventId, eEvent.eventId]));
 	});
+
+	it('should resolve correct state based on auth chain difference', async () => {
+		const events = [
+			// two memberships
+			// one join rule
+			new FakeEvent(
+				'EB',
+				EVELYN,
+				'm.room.member',
+				EVELYN,
+				MEMBERSHIP_CONTENT_JOIN,
+			),
+			new FakeEvent('JRI', ALICE, 'm.room.join_rules', '', {
+				join_rule: 'invite',
+			}),
+		];
+
+		const edges = [
+			['END', 'EB', 'IJR'],
+			['END', 'JRI', 'IJR'],
+		];
+
+		const finalState = await runTest(events, edges);
+
+		expect(finalState.get('m.room.join_rules:')).toHaveProperty(
+			'eventId',
+			'JRI:example.com',
+		);
+		expect(finalState.get('m.room.member:@evelyn:example.com')).toBeUndefined();
+	});
 });

--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -225,8 +225,16 @@ export async function resolveStateV2Plus(
 	// 2. Apply the iterative auth checks algorithm, starting from the unconflicted state map, to the list of events from the previous step to get a partially resolved state.
 	const initialState = new Map<StateMapKey, PersistentEventBase>();
 	for (const [key, eventId] of unconflicted) {
-		// self explanatory
-		const [event] = await wrappedStore.getEvents([eventId]);
+		// in layman's terms:
+		// FULL conflicted set = conflicted events + auth difference
+		// unconflicted already excludes conflicted events
+		// if initial state has an event that is in auth difference set, at the time of validating the events from auth difference,
+		// they will be allowed because they are already in the initial state.
+		// so initial state can only be unconflicted - authDifference
+		if (authChainDifference.has(eventId)) {
+			continue;
+		}
+		const event = await Promise.resolve(eventIdToEventMap.get(eventId)); // the cache MUST HAVE IT. The promise is just allowing the loop to be non blocking
 		assert(event, `event should not be null ${eventId}`);
 		initialState.set(key, event);
 	}

--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -234,7 +234,7 @@ export async function resolveStateV2Plus(
 		if (authChainDifference.has(eventId)) {
 			continue;
 		}
-		const event = await Promise.resolve(eventIdToEventMap.get(eventId)); // the cache MUST HAVE IT. The promise is just allowing the loop to be non blocking
+		const event = eventIdToEventMap.get(eventId);
 		assert(event, `event should not be null ${eventId}`);
 		initialState.set(key, event);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes state resolution edge cases involving authorization-chain differences to prevent incorrect join rules or member states.

* **Performance**
  * Improves responsiveness of state resolution by using in-memory caching for relevant events.

* **Tests**
  * Adds a test that verifies correct final room state when auth-chain differences and conflicting events are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->