### PR TITLE
refactor: enhance message content types and schemas

### DIFF
--- a/packages/core/src/events/m.room.message.ts
+++ b/packages/core/src/events/m.room.message.ts
@@ -1,15 +1,59 @@
 import { type EventBase, createEventBase } from './eventBase';
 import { createEventWithId } from './utils/createSignedEvent';
 
-type MessageType =
-	| 'm.text'
-	| 'm.emote'
-	| 'm.notice'
-	| 'm.image'
-	| 'm.file'
-	| 'm.audio'
-	| 'm.video'
-	| 'm.location';
+export type TextMessageType = 'm.text' | 'm.emote' | 'm.notice';
+export type FileMessageType = 'm.image' | 'm.file' | 'm.audio' | 'm.video';
+export type LocationMessageType = 'm.location';
+export type MessageType =
+	| TextMessageType
+	| FileMessageType
+	| LocationMessageType;
+
+// Base message content
+type BaseMessageContent = {
+	body: string;
+	'm.mentions'?: Record<string, any>;
+	format?: string;
+	formatted_body?: string;
+	'm.relates_to'?: MessageRelation;
+};
+
+// Text message content
+export type TextMessageContent = BaseMessageContent & {
+	msgtype: TextMessageType;
+};
+
+// File message content
+export type FileMessageContent = BaseMessageContent & {
+	msgtype: FileMessageType;
+	url: string;
+	info?: {
+		size?: number;
+		mimetype?: string;
+		w?: number;
+		h?: number;
+		duration?: number;
+		thumbnail_url?: string;
+		thumbnail_info?: {
+			w?: number;
+			h?: number;
+			mimetype?: string;
+			size?: number;
+		};
+	};
+};
+
+// Location message content
+export type LocationMessageContent = BaseMessageContent & {
+	msgtype: LocationMessageType;
+	geo_uri: string;
+};
+
+// New content for edits
+type NewContent =
+	| Pick<TextMessageContent, 'body' | 'msgtype' | 'format' | 'formatted_body'>
+	| Pick<FileMessageContent, 'body' | 'msgtype' | 'url' | 'info'>
+	| Pick<LocationMessageContent, 'body' | 'msgtype' | 'geo_uri'>;
 
 declare module './eventBase' {
 	interface Events {
@@ -17,19 +61,12 @@ declare module './eventBase' {
 			unsigned: {
 				age_ts: number;
 			};
-			content: {
-				body: string;
-				msgtype: MessageType;
-				'm.mentions'?: Record<string, any>;
-				format?: string;
-				formatted_body?: string;
-				'm.relates_to'?: MessageRelation;
-				'm.new_content'?: {
-					body: string;
-					msgtype: MessageType;
-					format?: string;
-					formatted_body?: string;
-				};
+			content: (
+				| TextMessageContent
+				| FileMessageContent
+				| LocationMessageContent
+			) & {
+				'm.new_content'?: NewContent;
 			};
 		};
 	}
@@ -67,19 +104,12 @@ export const isRoomMessageEvent = (
 
 export interface RoomMessageEvent extends EventBase {
 	type: 'm.room.message';
-	content: {
-		body: string;
-		msgtype: MessageType;
-		'm.mentions'?: Record<string, any>;
-		format?: string;
-		formatted_body?: string;
-		'm.relates_to'?: MessageRelation;
-		'm.new_content'?: {
-			body: string;
-			msgtype: MessageType;
-			format?: string;
-			formatted_body?: string;
-		};
+	content: (
+		| TextMessageContent
+		| FileMessageContent
+		| LocationMessageContent
+	) & {
+		'm.new_content'?: NewContent;
 	};
 	unsigned: {
 		age: number;
@@ -110,19 +140,12 @@ export const roomMessageEvent = ({
 	prev_events: string[];
 	depth: number;
 	unsigned?: RoomMessageEvent['unsigned'];
-	content: {
-		body: string;
-		msgtype: MessageType;
-		'm.mentions'?: Record<string, any>;
-		format?: string;
-		formatted_body?: string;
-		'm.relates_to'?: MessageRelation;
-		'm.new_content'?: {
-			body: string;
-			msgtype: MessageType;
-			format?: string;
-			formatted_body?: string;
-		};
+	content: (
+		| TextMessageContent
+		| FileMessageContent
+		| LocationMessageContent
+	) & {
+		'm.new_content'?: NewContent;
 	};
 	origin?: string;
 	ts?: number;

--- a/packages/federation-sdk/src/services/message.service.ts
+++ b/packages/federation-sdk/src/services/message.service.ts
@@ -26,6 +26,27 @@ import { FederationService } from './federation.service';
 import { RoomService } from './room.service';
 import { StateService } from './state.service';
 
+// File message content type
+export type FileMessageContent = {
+	body: string;
+	msgtype: 'm.image' | 'm.file' | 'm.video' | 'm.audio';
+	url: string;
+	info?: {
+		size?: number;
+		mimetype?: string;
+		w?: number;
+		h?: number;
+		duration?: number;
+		thumbnail_url?: string;
+		thumbnail_info?: {
+			w?: number;
+			h?: number;
+			mimetype?: string;
+			size?: number;
+		};
+	};
+};
+
 @singleton()
 export class MessageService {
 	private readonly logger = createLogger('MessageService');
@@ -121,25 +142,7 @@ export class MessageService {
 
 	async sendFileMessage(
 		roomId: string,
-		content: {
-			body: string;
-			msgtype: 'm.image' | 'm.file' | 'm.video' | 'm.audio';
-			url: string;
-			info?: {
-				size?: number;
-				mimetype?: string;
-				w?: number;
-				h?: number;
-				duration?: number;
-				thumbnail_url?: string;
-				thumbnail_info?: {
-					w?: number;
-					h?: number;
-					mimetype?: string;
-					size?: number;
-				};
-			};
-		},
+		content: FileMessageContent,
 		senderUserId: string,
 	): Promise<PersistentEventBase> {
 		const roomVersion = await this.stateService.getRoomVersion(roomId);


### PR DESCRIPTION
This pull request refactors how Matrix room message events are typed and validated, introducing more granular and explicit types for different message kinds (text, file, location) across the codebase. It also updates the message event schema to use discriminated unions for better type safety and extensibility. The changes improve clarity, maintainability, and validation for message content and edits.

**Type system improvements and refactoring:**

* Split the `MessageType` union into `TextMessageType`, `FileMessageType`, and `LocationMessageType`, and introduced corresponding content types (`TextMessageContent`, `FileMessageContent`, `LocationMessageContent`). The `RoomMessageEvent` and related functions now use these more specific types, with support for a discriminated union for edits (`NewContent`). [[1]](diffhunk://#diff-155fb57b9091928741a6e573a67896e667bc026b3237d32b2a472ad7ac4aba00L4-R69) [[2]](diffhunk://#diff-155fb57b9091928741a6e573a67896e667bc026b3237d32b2a472ad7ac4aba00L70-R112) [[3]](diffhunk://#diff-155fb57b9091928741a6e573a67896e667bc026b3237d32b2a472ad7ac4aba00L113-R148)

**Schema and validation enhancements:**

* Refactored the `PduMessageEventContentSchema` to use a discriminated union for message content, with dedicated schemas for text, file, and location messages. Added a detailed schema for file info and for new content in edits, improving validation and extensibility. [[1]](diffhunk://#diff-84859cdb92fb8b46121b03d0ddee3f45f4a8f36bef17219aaa5ef5f6de61a7e6L341-R355) [[2]](diffhunk://#diff-84859cdb92fb8b46121b03d0ddee3f45f4a8f36bef17219aaa5ef5f6de61a7e6L371-L376) [[3]](diffhunk://#diff-84859cdb92fb8b46121b03d0ddee3f45f4a8f36bef17219aaa5ef5f6de61a7e6L385-R487)

**Federation SDK alignment:**

* Updated the federation SDK (`message.service.ts`) to use the new `FileMessageContent` type for file messages, ensuring consistency with the core event types and schemas. [[1]](diffhunk://#diff-2d1c59ce4b490ce6007a025e9291d96698a827fee44662f6d12fd29ea8b25cf7R29-R49) [[2]](diffhunk://#diff-2d1c59ce4b490ce6007a025e9291d96698a827fee44662f6d12fd29ea8b25cf7L124-R145)