### PR TITLE
fix: use default power level when one isn't in state

### DIFF
--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -72,6 +72,7 @@ import {
 	partitionState,
 	reverseTopologicalPowerSort,
 } from '../definitions';
+import { PowerLevelEvent } from '@hs/room/manager/power-level-event-wrapper';
 
 export const isTruthy = <T>(
 	value: T | null | undefined | false | 0 | '',
@@ -268,9 +269,7 @@ export async function resolveStateV2Plus(
 
 	const powerLevelEvent = partiallyResolvedState.get(
 		getStateMapKey({ type: 'm.room.power_levels' }),
-	);
-
-	assert(powerLevelEvent, 'power level event should not be null');
+	) ?? (new PowerLevelEvent()).toEventBase();
 
 	// mainline ordering essentially sorts the rest of the events
 	// by their place in the history of the room's power levels.

--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -59,8 +59,8 @@
 
 import assert from 'node:assert';
 import { PersistentEventBase } from '../../../manager/event-wrapper';
+import { PowerLevelEvent } from '../../../manager/power-level-event-wrapper';
 import type { EventID, StateMapKey } from '../../../types/_common';
-import {} from '../../../types/v3-11';
 import {
 	type EventStore,
 	getAuthChain,
@@ -72,7 +72,6 @@ import {
 	partitionState,
 	reverseTopologicalPowerSort,
 } from '../definitions';
-import { PowerLevelEvent } from '@hs/room/manager/power-level-event-wrapper';
 
 export const isTruthy = <T>(
 	value: T | null | undefined | false | 0 | '',
@@ -267,9 +266,10 @@ export async function resolveStateV2Plus(
 	// ^^ non power events, since we should have power events figured out already, i.e. having single resolved power level event, single resolved join rules event, etc.
 	// we can validate if the rest of the events are "allowed" or not
 
-	const powerLevelEvent = partiallyResolvedState.get(
-		getStateMapKey({ type: 'm.room.power_levels' }),
-	) ?? (new PowerLevelEvent()).toEventBase();
+	const powerLevelEvent =
+		partiallyResolvedState.get(
+			getStateMapKey({ type: 'm.room.power_levels' }),
+		) ?? new PowerLevelEvent().toEventBase();
 
 	// mainline ordering essentially sorts the rest of the events
 	// by their place in the history of the room's power levels.


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/FDR-140

[FDR-140]: https://rocketchat.atlassian.net/browse/FDR-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved stability when processing room state by safely handling missing power settings, preventing rare crashes and sync failures in rooms with incomplete or corrupted history.
  * Reduces unexpected errors during membership changes, event authorization, and timeline loading in affected rooms.
  * Users should experience fewer sync interruptions, smoother room access, and more consistent behavior across clients when joining or viewing older rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->