### PR TITLE
Improve types of homeserver.matrix.message

### DIFF
--- a/packages/core/src/events/m.room.message.ts
+++ b/packages/core/src/events/m.room.message.ts
@@ -76,9 +76,14 @@ declare module './eventBase' {
 export type MessageRelation = {
 	rel_type: RelationType;
 	event_id: EventID;
-} & (RelationTypeReplace | Record<string, never>);
+} & (
+	| RelationTypeReplace
+	| RelationTypeAnnotation
+	| RelationTypeThread
+	| Record<string, never>
+);
 
-export type RelationType = 'm.replace' | 'm.annotation';
+export type RelationType = 'm.replace' | 'm.annotation' | 'm.thread';
 
 export type RelationTypeReplace = {
 	rel_type: 'm.replace';
@@ -89,6 +94,24 @@ export type RelationTypeReplace = {
 		format?: string;
 		formatted_body?: string;
 	};
+};
+
+export type RelationTypeAnnotation = {
+	rel_type: 'm.annotation';
+	event_id: EventID;
+	key: string;
+};
+
+export type RelationTypeThread = {
+	rel_type: 'm.thread';
+	event_id: EventID;
+	'm.in_reply_to'?: {
+		event_id: EventID;
+		room_id: string;
+		sender: string;
+		origin_server_ts: number;
+	};
+	is_falling_back?: boolean;
 };
 
 export type MessageAuthEvents = {

--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -144,6 +144,33 @@ export type HomeserverEventSignatures = {
 				'm.mentions'?: Record<string, string>;
 			};
 			formatted_body?: string;
+			info?: {
+				mimetype?: string;
+				w?: number;
+				h?: number;
+				size?: number;
+				thumbnail_file?: {
+					hashes: {
+						sha256: string;
+					};
+					iv: string;
+					key: {
+						alg: string;
+						ext: boolean;
+						k: string;
+						key_ops: ['encrypt' | 'decrypt'];
+						kty: string;
+					};
+					url: string;
+					v: 'v2';
+				};
+				thumbnail_info?: {
+					w?: number;
+					h?: number;
+					size?: number;
+					mimetype?: string;
+				};
+			};
 		};
 	};
 	'homeserver.matrix.accept-invite': {

--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import type { Membership } from '@hs/core';
+import type { Membership, MessageType } from '@hs/core';
 import type { EventID } from '@hs/room';
 import { container } from 'tsyringe';
 import { ConfigService } from './services/config.service';
@@ -115,20 +115,32 @@ export type HomeserverEventSignatures = {
 		origin_server_ts: number;
 		content: {
 			body: string;
-			msgtype: string;
-			'm.relates_to'?: {
-				rel_type: 'm.replace' | 'm.annotation' | 'm.thread';
-				event_id: EventID;
-				'm.in_reply_to'?: {
-					event_id: EventID;
-					room_id: string;
-					sender: string;
-					origin_server_ts: number;
-				};
-			};
+			msgtype: MessageType;
+			url?: string;
+			'm.relates_to'?:
+				| {
+						rel_type: 'm.replace';
+						event_id: EventID;
+				  }
+				| {
+						rel_type: 'm.annotation';
+						event_id: EventID;
+						key: string;
+				  }
+				| {
+						rel_type: 'm.thread';
+						event_id: EventID;
+						'm.in_reply_to'?: {
+							event_id: EventID;
+							room_id: string;
+							sender: string;
+							origin_server_ts: number;
+						};
+						is_falling_back?: boolean;
+				  };
 			'm.new_content'?: {
 				body: string;
-				msgtype: string;
+				msgtype: MessageType;
 				'm.mentions'?: Record<string, string>;
 			};
 			formatted_body?: string;

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -1,5 +1,6 @@
 import { EventBase, HttpException, HttpStatus } from '@hs/core';
 import {
+	PduForType,
 	PersistentEventBase,
 	PersistentEventFactory,
 	RoomVersion,
@@ -125,9 +126,12 @@ export class InviteService {
 		};
 	}
 
-	async processInvite<
-		T extends PersistentEventBase<RoomVersion, 'm.room.member'>,
-	>(event: T, roomId: string, eventId: string, roomVersion: RoomVersion) {
+	async processInvite(
+		event: PduForType<'m.room.member'>,
+		roomId: string,
+		eventId: string,
+		roomVersion: RoomVersion,
+	) {
 		// SPEC: when a user invites another user on a different homeserver, a request to that homeserver to have the event signed and verified must be made
 
 		const residentServer = roomId.split(':').pop();
@@ -137,9 +141,7 @@ export class InviteService {
 
 		const inviteEvent =
 			PersistentEventFactory.createFromRawEvent<'m.room.member'>(
-				event as unknown as Parameters<
-					typeof PersistentEventFactory.createFromRawEvent
-				>[0],
+				event,
 				roomVersion,
 			);
 

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -1,5 +1,9 @@
 import { EventBase, HttpException, HttpStatus } from '@hs/core';
-import { PersistentEventFactory, RoomVersion } from '@hs/room';
+import {
+	PersistentEventBase,
+	PersistentEventFactory,
+	RoomVersion,
+} from '@hs/room';
 import { singleton } from 'tsyringe';
 import { createLogger } from '../utils/logger';
 import { ConfigService } from './config.service';
@@ -122,11 +126,7 @@ export class InviteService {
 	}
 
 	async processInvite<
-		T extends Omit<EventBase, 'origin'> & {
-			origin?: string | undefined;
-			room_id: string;
-			state_key: string;
-		},
+		T extends PersistentEventBase<RoomVersion, 'm.room.member'>,
 	>(event: T, roomId: string, eventId: string, roomVersion: RoomVersion) {
 		// SPEC: when a user invites another user on a different homeserver, a request to that homeserver to have the event signed and verified must be made
 
@@ -135,12 +135,13 @@ export class InviteService {
 			throw new Error(`Invalid roomId ${roomId}`);
 		}
 
-		const inviteEvent = PersistentEventFactory.createFromRawEvent(
-			event as unknown as Parameters<
-				typeof PersistentEventFactory.createFromRawEvent
-			>[0],
-			roomVersion,
-		);
+		const inviteEvent =
+			PersistentEventFactory.createFromRawEvent<'m.room.member'>(
+				event as unknown as Parameters<
+					typeof PersistentEventFactory.createFromRawEvent
+				>[0],
+				roomVersion,
+			);
 
 		if (inviteEvent.eventId !== eventId) {
 			throw new Error(`Invalid eventId ${eventId}`);

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -1,8 +1,8 @@
 import type { EventBase, EventStagingStore, Membership } from '@hs/core';
 import { singleton } from 'tsyringe';
 
-import { createLogger, isRedactedEvent } from '@hs/core';
-import { Pdu, PduPowerLevelsEventContent } from '@hs/room';
+import { MessageType, createLogger, isRedactedEvent } from '@hs/core';
+import { PduPowerLevelsEventContent } from '@hs/room';
 import type { EventID } from '@hs/room';
 import { EventAuthorizationService } from './event-authorization.service';
 import { EventEmitterService } from './event-emitter.service';
@@ -148,14 +148,24 @@ export class StagingAreaService {
 					content: {
 						...event.event.content,
 						body: event.event.content?.body as string,
-						msgtype: event.event.content?.msgtype as string,
-						'm.relates_to': event.event.content?.['m.relates_to'] as {
-							rel_type: 'm.replace' | 'm.annotation' | 'm.thread';
-							event_id: EventID;
-						},
+						msgtype: event.event.content?.msgtype as MessageType,
+						'm.relates_to': event.event.content?.['m.relates_to'] as
+							| {
+									rel_type: 'm.replace';
+									event_id: EventID;
+							  }
+							| {
+									rel_type: 'm.annotation';
+									event_id: EventID;
+									key: string;
+							  }
+							| {
+									rel_type: 'm.thread';
+									event_id: EventID;
+							  },
 						'm.new_content': event.event.content?.['m.new_content'] as {
 							body: string;
-							msgtype: string;
+							msgtype: MessageType;
 						},
 						formatted_body: (event.event.content?.formatted_body ||
 							'') as string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for message relations: edits, reactions, and threads with optional fallback and nested reply metadata.
  * Added optional URL field on messages for richer content handling.
  * Expanded media/thumbnail metadata for messages (mimetype, dimensions, size, thumbnail file/info and hashes).

* **Refactor**
  * Standardized message type across message payloads for stronger validation and consistency, including in edited/new content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->