### PR TITLE
fix: return origin on make-join response event

### DIFF
--- a/packages/federation-sdk/src/services/profiles.service.ts
+++ b/packages/federation-sdk/src/services/profiles.service.ts
@@ -73,7 +73,7 @@ export class ProfilesService {
 		userId: string,
 		versions: RoomVersion[], // asking server supports these
 	): Promise<{
-		event: PduForType<'m.room.member'>;
+		event: PduForType<'m.room.member'> & { origin: string };
 		room_version: string;
 	}> {
 		const stateService = this.stateService;
@@ -102,7 +102,10 @@ export class ProfilesService {
 
 		return {
 			room_version: roomVersion,
-			event: membershipEvent.event,
+			event: {
+				...membershipEvent.event,
+				origin: this.configService.serverName,
+			},
 		};
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added origin metadata to federation member join events to enrich event payloads.
  * Adjusted internal return structures accordingly.
* **Chores**
  * Updated internal types to align with the enhanced event data.

No user-facing changes; existing functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->