### PR TITLE
fix: typing and missing pl handling

### DIFF
--- a/packages/room/src/manager/event-wrapper.ts
+++ b/packages/room/src/manager/event-wrapper.ts
@@ -68,8 +68,8 @@ export abstract class PersistentEventBase<
 		return this.rawEvent.hashes.sha256;
 	}
 
-	get type() {
-		return this.rawEvent.type;
+	get type(): Type {
+		return this.rawEvent.type as Type;
 	}
 
 	get roomId() {
@@ -135,7 +135,7 @@ export abstract class PersistentEventBase<
 
 	toPowerLevelEvent() {
 		if (this.isPowerLevelEvent()) {
-			return new PowerLevelEvent(this);
+			return PowerLevelEvent.fromEvent(this);
 		}
 
 		throw new Error('Event is not a power level event');

--- a/packages/room/src/manager/power-level-event-wrapper.ts
+++ b/packages/room/src/manager/power-level-event-wrapper.ts
@@ -10,22 +10,29 @@ import { RoomVersion } from './type';
 // whether there is an event or not
 // all defaults and transformations according to diff versions of pdus
 
-class PowerLevelEvent {
+class PowerLevelEvent<
+	PowerLevelEventType extends
+		| PersistentEventBase<RoomVersion, 'm.room.power_levels'>
+		| undefined = PersistentEventBase<RoomVersion, 'm.room.power_levels'>,
+> {
 	private readonly _content?: PduPowerLevelsEventContent;
 
-	static fromEvent(event?: PersistentEventBase) {
+	static fromEvent(
+		event: PersistentEventBase<RoomVersion, 'm.room.power_levels'>,
+	) {
 		return new PowerLevelEvent(event);
 	}
 
-	constructor(private readonly event?: PersistentEventBase) {
+	static fromDefault() {
+		return new PowerLevelEvent(undefined);
+	}
+
+	private constructor(private readonly event: PowerLevelEventType) {
 		this._content = event?.getContent();
 	}
 
-	toEventBase(): PersistentEventBase<RoomVersion, 'm.room.power_levels'> {
-		return this.event as PersistentEventBase<
-			RoomVersion,
-			'm.room.power_levels'
-		>;
+	toEventBase() {
+		return this.event;
 	}
 
 	// power level event accessors
@@ -175,10 +182,6 @@ class PowerLevelEvent {
 		}
 
 		return this._content.users?.[userId];
-	}
-
-	exists() {
-		return !!this._content;
 	}
 
 	get sender() {

--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -266,10 +266,9 @@ export async function resolveStateV2Plus(
 	// ^^ non power events, since we should have power events figured out already, i.e. having single resolved power level event, single resolved join rules event, etc.
 	// we can validate if the rest of the events are "allowed" or not
 
-	const powerLevelEvent =
-		getStateByMapKey(partiallyResolvedState, {
-			type: 'm.room.power_levels',
-		}) ?? new PowerLevelEvent().toEventBase();
+	const powerLevelEvent = getStateByMapKey(partiallyResolvedState, {
+		type: 'm.room.power_levels',
+	});
 
 	// mainline ordering essentially sorts the rest of the events
 	// by their place in the history of the room's power levels.
@@ -285,9 +284,8 @@ export async function resolveStateV2Plus(
 
 	const orderedRemainingEvents = await mainlineOrdering(
 		sanitizedRemainingEvents,
-		powerLevelEvent,
-		initialState,
 		wrappedStore,
+		powerLevelEvent,
 	);
 
 	// 4. Apply the iterative auth checks algorithm on the partial resolved state and the list of events from the previous step.

--- a/packages/room/src/state_resolution/definitions/definitions.ts
+++ b/packages/room/src/state_resolution/definitions/definitions.ts
@@ -369,10 +369,10 @@ export async function reverseTopologicalPowerSort(
 		}
 
 		if (!eventToPowerLevelMap.has(event.eventId)) {
-			// insert a fake power level event for the power event
+			// use default power level
 			eventToPowerLevelMap.set(
 				event.eventId,
-				new PowerLevelEvent().getPowerLevelForUser(
+				PowerLevelEvent.fromDefault().getPowerLevelForUser(
 					event.sender,
 					roomCreateEvent,
 				),
@@ -400,8 +400,8 @@ export async function reverseTopologicalPowerSort(
 		const sender2PowerLevel = eventToPowerLevelMap.get(event2Id);
 
 		if (
-			sender1PowerLevel &&
-			sender2PowerLevel &&
+			sender1PowerLevel !== undefined &&
+			sender2PowerLevel !== undefined &&
 			sender1PowerLevel !== sender2PowerLevel
 		) {
 			return sender2PowerLevel - sender1PowerLevel;
@@ -422,18 +422,23 @@ export async function reverseTopologicalPowerSort(
 	});
 }
 
-// FIXME:
 export async function mainlineOrdering(
 	events: PersistentEventBase[], // TODO: or take event ids
-	// Let P = P0 be an m.room.power_levels event
-	powerLevelEvent: PersistentEventBase, // of which we will calculate the mainline
-	_authEventMap: Map<StateMapKey, PersistentEventBase>,
 	store: EventStore,
+	// Let P = P0 be an m.room.power_levels event
+	powerLevelEvent?: PersistentEventBase, // of which we will calculate the mainline
 ): Promise<PersistentEventBase[]> {
-	const getMainline = async (event: PersistentEventBase) => {
-		const mainline = [] as PersistentEventBase[];
+	const getMainline = async (
+		event: PersistentEventBase<RoomVersion, 'm.room.power_levels'>,
+	) => {
+		const mainline = [] as PersistentEventBase<
+			RoomVersion,
+			'm.room.power_levels'
+		>[];
 
-		const fn = async (event: PersistentEventBase) => {
+		const fn = async (
+			event: PersistentEventBase<RoomVersion, 'm.room.power_levels'>,
+		) => {
 			const authEvents = await event.getAuthorizationEvents(store);
 
 			// await new Promise((resolve) => setTimeout(resolve, 3000));
@@ -459,11 +464,11 @@ export async function mainlineOrdering(
 	};
 
 	// this is how we get the mainline of an event
-	const mainline = await getMainline(powerLevelEvent);
-
-	mainline.unshift(powerLevelEvent); // add the power level event to the mainline
-
-	assert(mainline && mainline.length > 0, 'mainline should not be empty');
+	let mainline: Awaited<ReturnType<typeof getMainline>> = [];
+	if (powerLevelEvent?.isPowerLevelEvent()) {
+		mainline = await getMainline(powerLevelEvent);
+		mainline.unshift(powerLevelEvent); // add the power level event to the mainline
+	}
 
 	const mainlinePositions = new Map<EventID, number>(); // NOTE: see comment in the loop
 
@@ -534,19 +539,20 @@ export async function mainlineOrdering(
 		// the mainline position of x is greater than the mainline position of y
 		const e1Position = mainlinePositions.get(e1.eventId);
 		const e2Position = mainlinePositions.get(e2.eventId);
-		if (e1Position && e2Position && e1Position < e2Position) return -1;
+		if (
+			e1Position !== undefined &&
+			e2Position !== undefined &&
+			e1Position < e2Position
+		)
+			return -1;
 
 		// x’s origin_server_ts is less than y’s origin_server_ts
-		if (e1.originServerTs < e2.originServerTs) {
-			return -1;
+		if (e1.originServerTs !== e2.originServerTs) {
+			return e1.originServerTs - e2.originServerTs;
 		}
 
 		// x’s event_id is less than y’s event_id.ents: V2Pd
-		if (e1.eventId < e2.eventId) {
-			return -1;
-		}
-
-		return 1;
+		return e1.eventId.localeCompare(e2.eventId);
 	};
 
 	return events.sort(comparisonFn);

--- a/packages/room/src/state_resolution/definitions/definitions.ts
+++ b/packages/room/src/state_resolution/definitions/definitions.ts
@@ -464,9 +464,11 @@ export async function mainlineOrdering(
 	};
 
 	// this is how we get the mainline of an event
-	let mainline: Awaited<ReturnType<typeof getMainline>> = [];
+	const mainline: PersistentEventBase<RoomVersion, 'm.room.power_levels'>[] =
+		[];
+
 	if (powerLevelEvent?.isPowerLevelEvent()) {
-		mainline = await getMainline(powerLevelEvent);
+		mainline.push(...(await getMainline(powerLevelEvent)));
 		mainline.unshift(powerLevelEvent); // add the power level event to the mainline
 	}
 


### PR DESCRIPTION
primarily handles missing pl, but also found other minor bugs in the same area so added to same pr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Membership and power-level changes now tolerate rooms missing a power-levels event, avoiding crashes and authorization failures.
  * State resolution and event ordering handle absent power-level data more robustly.

* **Refactor**
  * Permission checks and ordering logic updated to use null-safe handling and explicit defaults when power-level info is missing.

* **Tests**
  * Added tests for membership and power-level changes without an existing power-levels event.
  * Added mainline ordering test covering no power-levels scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->