### PR TITLE
refactor: replace getStateMapKey with getStateByMapKey

### DIFF
--- a/packages/room/src/authorizartion-rules/rules.spec.ts
+++ b/packages/room/src/authorizartion-rules/rules.spec.ts
@@ -1,14 +1,13 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { PersistentEventBase } from '../manager/event-wrapper';
 import { PersistentEventFactory } from '../manager/factory';
-import type { EventStore } from '../state_resolution/definitions/definitions';
+import {
+	type EventStore,
+	getStateMapKey,
+} from '../state_resolution/definitions/definitions';
 import { type StateMapKey } from '../types/_common';
 import { Pdu, PduContent, type PduType } from '../types/v3-11';
 import { checkEventAuthWithState, checkEventAuthWithoutState } from './rules';
-
-function getStateMapKey(event: PersistentEventBase): StateMapKey {
-	return `${event.type}:${event.stateKey ?? ''}`;
-}
 
 class MockStore implements EventStore {
 	events: Map<string, PersistentEventBase> = new Map();
@@ -164,7 +163,7 @@ function getInitialEvents(
 
 function getStateMap(events: PersistentEventBase[]) {
 	return new Map<StateMapKey, PersistentEventBase>(
-		events.map((event) => [getStateMapKey(event), event]),
+		events.map((event) => [getStateMapKey(event.event), event]),
 	);
 }
 

--- a/packages/room/src/manager/room-state.ts
+++ b/packages/room/src/manager/room-state.ts
@@ -1,4 +1,4 @@
-import { getStateMapKey } from '../state_resolution/definitions/definitions';
+import { getStateByMapKey } from '../state_resolution/definitions/definitions';
 import { StateMapKey } from '../types/_common';
 import {
 	PduCreateEventContent,
@@ -19,9 +19,10 @@ export class RoomState {
 
 	// who created the room
 	get creator() {
-		const createEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.create' }),
-		);
+		const createEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.create',
+		});
+
 		if (!createEvent || !createEvent.isCreateEvent()) {
 			throw new Error('Room create event not found');
 		}
@@ -32,9 +33,10 @@ export class RoomState {
 	getUserMembership(
 		userId: string,
 	): PduMembershipEventContent['membership'] | undefined {
-		const membershipEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.member', state_key: userId }),
-		);
+		const membershipEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.member',
+			state_key: userId,
+		});
 		if (!membershipEvent || !membershipEvent.isMembershipEvent()) {
 			return undefined; // never been a member
 		}
@@ -65,9 +67,9 @@ export class RoomState {
 
 	// name of the room
 	get name() {
-		const nameEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.name' }),
-		);
+		const nameEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.name',
+		});
 		if (!nameEvent || !nameEvent.isNameEvent()) {
 			throw new Error('Room name event not found');
 		}
@@ -77,9 +79,9 @@ export class RoomState {
 
 	// room privacy
 	get privacy(): PduJoinRuleEventContent['join_rule'] {
-		const joinRuleEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.join_rules' }),
-		);
+		const joinRuleEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.join_rules',
+		});
 		if (!joinRuleEvent || !joinRuleEvent.isJoinRuleEvent()) {
 			return 'public'; // default TODO: check this if is correct
 		}
@@ -101,9 +103,9 @@ export class RoomState {
 	}
 
 	get topic() {
-		const topicEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.topic' }),
-		);
+		const topicEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.topic',
+		});
 		if (!topicEvent || !topicEvent.isTopicEvent()) {
 			return '';
 		}
@@ -113,9 +115,9 @@ export class RoomState {
 
 	// origin is the origin of the room gotten from the room id
 	get origin() {
-		const createEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.create' }),
-		);
+		const createEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.create',
+		});
 
 		if (!createEvent) {
 			throw new Error('Room create event not found');
@@ -130,9 +132,9 @@ export class RoomState {
 	}
 
 	get powerLevels() {
-		const powerLevelsEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.power_levels' }),
-		);
+		const powerLevelsEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.power_levels',
+		});
 
 		if (!powerLevelsEvent || !powerLevelsEvent.isPowerLevelEvent()) {
 			return undefined;
@@ -142,9 +144,9 @@ export class RoomState {
 	}
 
 	get version() {
-		const createEvent = this.stateMap.get(
-			getStateMapKey({ type: 'm.room.create' }),
-		);
+		const createEvent = getStateByMapKey(this.stateMap, {
+			type: 'm.room.create',
+		});
 		if (!createEvent || !createEvent.isCreateEvent()) {
 			throw new Error('Room create event not found');
 		}

--- a/packages/room/src/state_resolution/definitions/algorithm/v2.ts
+++ b/packages/room/src/state_resolution/definitions/algorithm/v2.ts
@@ -65,7 +65,7 @@ import {
 	type EventStore,
 	getAuthChain,
 	getAuthChainDifference,
-	getStateMapKey,
+	getStateByMapKey,
 	isPowerEvent,
 	iterativeAuthChecks,
 	mainlineOrdering,
@@ -267,9 +267,9 @@ export async function resolveStateV2Plus(
 	// we can validate if the rest of the events are "allowed" or not
 
 	const powerLevelEvent =
-		partiallyResolvedState.get(
-			getStateMapKey({ type: 'm.room.power_levels' }),
-		) ?? new PowerLevelEvent().toEventBase();
+		getStateByMapKey(partiallyResolvedState, {
+			type: 'm.room.power_levels',
+		}) ?? new PowerLevelEvent().toEventBase();
 
 	// mainline ordering essentially sorts the rest of the events
 	// by their place in the history of the room's power levels.

--- a/packages/room/src/state_resolution/definitions/definitions.ts
+++ b/packages/room/src/state_resolution/definitions/definitions.ts
@@ -6,12 +6,23 @@ import assert from 'node:assert';
 import { checkEventAuthWithState } from '../../authorizartion-rules/rules';
 import type { PersistentEventBase } from '../../manager/event-wrapper';
 import { PowerLevelEvent } from '../../manager/power-level-event-wrapper';
+import { RoomVersion } from '../../manager/type';
 
 export function getStateMapKey(event: {
 	type: PduType;
 	state_key?: string;
 }): StateMapKey {
 	return `${event.type}:${event.state_key ?? ''}`;
+}
+
+export function getStateByMapKey<T extends PduType>(
+	map: Map<StateMapKey, PersistentEventBase>,
+	filter: {
+		type: T;
+		state_key?: string;
+	},
+): PersistentEventBase<RoomVersion, T> | undefined {
+	return map.get(getStateMapKey(filter)) as PersistentEventBase<RoomVersion, T>;
 }
 
 // https://spec.matrix.org/v1.12/rooms/v2/#definitions
@@ -308,9 +319,9 @@ export async function reverseTopologicalPowerSort(
 
 	const eventToPowerLevelMap = new Map<EventID, number>();
 
-	const roomCreateEvent = stateMap.get(
-		getStateMapKey({ type: 'm.room.create' }),
-	);
+	const roomCreateEvent = getStateByMapKey(stateMap, {
+		type: 'm.room.create',
+	});
 
 	if (!roomCreateEvent) {
 		throw new Error('room create event not found');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized room state lookups across the app using a unified helper, improving consistency and reducing edge-case errors in authorization checks and state retrieval.
  * Simplified internal logic for reading room metadata (creator, membership, name, privacy, topic, power levels, version), enhancing reliability and maintainability without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->