### PR TITLE
refactor: state resolution error propagation

### DIFF
--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -1,7 +1,6 @@
 import { EventBase, createLogger } from '@rocket.chat/federation-core';
 import {
 	PduForType,
-	PersistentEventBase,
 	PersistentEventFactory,
 	RoomVersion,
 } from '@rocket.chat/federation-room';

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -85,7 +85,7 @@ export class InviteService {
 			await stateService.persistStateEvent(inviteEvent);
 
 			if (inviteEvent.rejected) {
-				throw new Error(inviteEvent.rejectedReason);
+				throw new Error(inviteEvent.rejectReason);
 			}
 
 			// let all servers know of this state change
@@ -156,7 +156,7 @@ export class InviteService {
 
 			await this.stateService.persistStateEvent(inviteEvent);
 			if (inviteEvent.rejected) {
-				throw new Error(inviteEvent.rejectedReason);
+				throw new Error(inviteEvent.rejectReason);
 			}
 
 			// we do not send transaction here
@@ -173,7 +173,7 @@ export class InviteService {
 			// if we have the state we try to persist the invite event
 			await this.stateService.persistStateEvent(inviteEvent);
 			if (inviteEvent.rejected) {
-				throw new Error(inviteEvent.rejectedReason);
+				throw new Error(inviteEvent.rejectReason);
 			}
 		} catch (e) {
 			// don't have state copy yet

--- a/packages/federation-sdk/src/services/message.service.ts
+++ b/packages/federation-sdk/src/services/message.service.ts
@@ -1,23 +1,8 @@
-import {
-	type MessageAuthEvents,
-	type RoomMessageEvent,
-	roomMessageEvent,
-} from '@rocket.chat/federation-core';
-import { type SignedEvent } from '@rocket.chat/federation-core';
-
 import { ForbiddenError } from '@rocket.chat/federation-core';
-import {
-	type RedactionAuthEvents,
-	type RedactionEvent,
-	redactionEvent,
-} from '@rocket.chat/federation-core';
 import { createLogger } from '@rocket.chat/federation-core';
-import { signEvent } from '@rocket.chat/federation-core';
 import {
 	type EventID,
 	type PersistentEventBase,
-	PersistentEventFactory,
-	type RoomVersion,
 } from '@rocket.chat/federation-room';
 import { singleton } from 'tsyringe';
 import { EventRepository } from '../repositories/event.repository';

--- a/packages/federation-sdk/src/services/message.service.ts
+++ b/packages/federation-sdk/src/services/message.service.ts
@@ -82,7 +82,7 @@ export class MessageService {
 
 		await this.stateService.persistTimelineEvent(event);
 		if (event.rejected) {
-			throw new Error(event.rejectedReason);
+			throw new Error(event.rejectReason);
 		}
 
 		void this.federationService.sendEventToAllServersInRoom(event);
@@ -130,7 +130,7 @@ export class MessageService {
 
 		await this.stateService.persistTimelineEvent(event);
 		if (event.rejected) {
-			throw new Error(event.rejectedReason);
+			throw new Error(event.rejectReason);
 		}
 
 		void this.federationService.sendEventToAllServersInRoom(event);
@@ -166,7 +166,7 @@ export class MessageService {
 
 		await this.stateService.persistTimelineEvent(event);
 		if (event.rejected) {
-			throw new Error(event.rejectedReason);
+			throw new Error(event.rejectReason);
 		}
 
 		void this.federationService.sendEventToAllServersInRoom(event);
@@ -222,7 +222,7 @@ export class MessageService {
 
 		await this.stateService.persistTimelineEvent(event);
 		if (event.rejected) {
-			throw new Error(event.rejectedReason);
+			throw new Error(event.rejectReason);
 		}
 
 		void this.federationService.sendEventToAllServersInRoom(event);
@@ -273,7 +273,7 @@ export class MessageService {
 
 		await this.stateService.persistTimelineEvent(event);
 		if (event.rejected) {
-			throw new Error(event.rejectedReason);
+			throw new Error(event.rejectReason);
 		}
 
 		void this.federationService.sendEventToAllServersInRoom(event);

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -1,17 +1,10 @@
 import {
 	EventBase,
 	EventStore,
-	RoomNameAuthEvents,
 	RoomPowerLevelsEvent,
-	RoomTombstoneEvent,
 	SignedEvent,
 	TombstoneAuthEvents,
-	generateId,
-	isRoomPowerLevelsEvent,
-	roomNameEvent,
 	roomPowerLevelsEvent,
-	roomTombstoneEvent,
-	signEvent,
 } from '@rocket.chat/federation-core';
 import { singleton } from 'tsyringe';
 import { FederationService } from './federation.service';
@@ -21,18 +14,15 @@ import {
 	HttpException,
 	HttpStatus,
 } from '@rocket.chat/federation-core';
-import { type SigningKey } from '@rocket.chat/federation-core';
 
 import { logger } from '@rocket.chat/federation-core';
 import {
 	type EventID,
-	PduCreateEventContent,
 	PduForType,
 	PduJoinRuleEventContent,
 	PduType,
 	PersistentEventBase,
 	PersistentEventFactory,
-	RoomVersion,
 } from '@rocket.chat/federation-room';
 import { EventRepository } from '../repositories/event.repository';
 import { RoomRepository } from '../repositories/room.repository';

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -800,7 +800,7 @@ export class RoomService {
 			await stateService.persistStateEvent(membershipEvent);
 
 			if (membershipEvent.rejected) {
-				throw new Error(membershipEvent.rejectedReason);
+				throw new Error(membershipEvent.rejectReason);
 			}
 
 			void federationService.sendEventToAllServersInRoom(membershipEvent);
@@ -983,7 +983,7 @@ export class RoomService {
 		);
 
 		if (joinEventFinal.rejected) {
-			throw new Error(joinEventFinal.rejectedReason);
+			throw new Error(joinEventFinal.rejectReason);
 		}
 
 		return joinEventFinal.eventId;

--- a/packages/federation-sdk/src/services/send-join.service.ts
+++ b/packages/federation-sdk/src/services/send-join.service.ts
@@ -50,7 +50,7 @@ export class SendJoinService {
 		await stateService.persistStateEvent(joinEvent);
 
 		if (joinEvent.rejected) {
-			throw new Error(joinEvent.rejectedReason);
+			throw new Error(joinEvent.rejectReason);
 		}
 
 		const configService = this.configService;

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -750,7 +750,7 @@ export class StateService {
 
 		// we need the auth events required to validate this event from our state
 		const requiredAuthEventsWeHaveSeenMap = new Map<
-			string,
+			EventID,
 			PersistentEventBase
 		>();
 		for (const auth of event.getAuthEventStateKeys()) {

--- a/packages/homeserver/src/controllers/internal/invite.controller.ts
+++ b/packages/homeserver/src/controllers/internal/invite.controller.ts
@@ -61,7 +61,7 @@ export const internalInvitePlugin = (app: Elysia) => {
 			await stateService.persistStateEvent(membershipEvent);
 
 			if (membershipEvent.rejected) {
-				throw new Error(membershipEvent.rejectedReason);
+				throw new Error(membershipEvent.rejectReason);
 			}
 
 			return {

--- a/packages/room/src/authorizartion-rules/errors.ts
+++ b/packages/room/src/authorizartion-rules/errors.ts
@@ -1,4 +1,4 @@
-import { PersistentEventBase } from '../manager/event-wrapper';
+import type { PersistentEventBase } from '../manager/event-wrapper';
 import { type EventID } from '../types/_common';
 
 export const RejectCodes = {

--- a/packages/room/src/authorizartion-rules/rules.ts
+++ b/packages/room/src/authorizartion-rules/rules.ts
@@ -9,7 +9,7 @@ import {
 	getStateByMapKey,
 } from '../state_resolution/definitions/definitions';
 import { type StateMapKey } from '../types/_common';
-import { StateResolverAuthorizationError } from './errors';
+import { RejectCodes, StateResolverAuthorizationError } from './errors';
 
 // https://spec.matrix.org/v1.12/rooms/v1/#authorization-rules
 // skip if not any of the specified type of events
@@ -27,30 +27,23 @@ function extractDomain(identifier: string) {
 	return identifier.split(':').pop();
 }
 
-function isCreateAllowed(createEvent: PersistentEventBase) {
-	if (!createEvent.isCreateEvent()) {
-		throw new StateResolverAuthorizationError('m.room.create event not found', {
-			eventFailed: createEvent,
-		});
-	}
+function isCreateAllowed(
+	createEvent: PersistentEventBase<RoomVersion, 'm.room.create'>,
+) {
 	// If it has any prev_events, reject.
 	if (createEvent.event.prev_events.length > 0) {
-		throw new StateResolverAuthorizationError(
-			'm.room.create event has prev_events',
-			{
-				eventFailed: createEvent,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: createEvent,
+			reason: 'm.room.create event has prev_events',
+		});
 	}
 
 	// If the domain of the room_id does not match the domain of the sender, reject.
 	if (extractDomain(createEvent.roomId) !== extractDomain(createEvent.sender)) {
-		throw new StateResolverAuthorizationError(
-			'm.room.create event sender domain does not match room_id domain',
-			{
-				eventFailed: createEvent,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: createEvent,
+			reason: 'm.room.create event sender domain does not match room_id domain',
+		});
 	}
 
 	const content = createEvent.getContent();
@@ -111,12 +104,10 @@ async function isMembershipChangeAllowed(
 		!membershipEventToCheck.stateKey ||
 		!membershipEventToCheck.isMembershipEvent()
 	) {
-		throw new StateResolverAuthorizationError(
-			'm.room.member event has no state_key or membership property',
-			{
-				eventFailed: membershipEventToCheck,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: membershipEventToCheck,
+			reason: 'm.room.member event has no state_key or membership property',
+		});
 	}
 
 	// sender -> who asked for the change
@@ -193,12 +184,19 @@ async function isMembershipChangeAllowed(
 
 			// If the sender does not match state_key, reject.
 			if (sender !== invitee) {
-				throw new Error('state_key does not match the sender');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'state_key does not match the sender',
+				});
 			}
 
 			// If the sender is banned, reject.
 			if (senderMembership === 'ban') {
-				throw new Error('sender is banned');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'sender is banned',
+					rejectedBy: senderMembershipEvent,
+				});
 			}
 
 			// If the join_rule is public, allow.
@@ -212,13 +210,19 @@ async function isMembershipChangeAllowed(
 					return;
 				}
 
-				throw new Error(
-					'join_rule is invite but membership is not invite or join',
-				);
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					rejectedBy: joinRuleEvent,
+					reason: 'join_rule is invite but membership is not invite or join',
+				});
 			}
 
 			// otherwise reject
-			throw new Error('join_rule is not public or invite');
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: membershipEventToCheck,
+				rejectedBy: joinRuleEvent,
+				reason: 'join_rule is not public or invite',
+			});
 		}
 
 		case 'invite': {
@@ -246,17 +250,28 @@ async function isMembershipChangeAllowed(
 
 				// // If there is no m.room.third_party_invite event in the current room state with state_key matching token, reject.
 
-				throw new Error('third_party_invite not implemented');
+				throw new StateResolverAuthorizationError(RejectCodes.NotImplemented, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'third_party_invite not implemented',
+				});
 			}
 
 			// If the sender’s current membership state is not join, reject.
 			if (senderMembership !== 'join') {
-				throw new Error('sender is not part of the room');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'sender is not part of the room',
+					rejectedBy: senderMembershipEvent,
+				});
 			}
 
 			// If target user’s current membership state is join or ban, reject.
 			if (inviteeMembership === 'join' || inviteeMembership === 'ban') {
-				throw new Error('invitee is not join or ban');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'invitee is already join or ban',
+					rejectedBy: inviteeMembershipEvent,
+				});
 			}
 
 			// If the sender’s power level is greater than or equal to the invite level, allow.
@@ -272,7 +287,11 @@ async function isMembershipChangeAllowed(
 				return;
 			}
 
-			throw new Error('sender power level is less than invite level');
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: membershipEventToCheck,
+				reason: `sender power level is less than invite level (${senderPowerLevel} < ${inviteLevel})`,
+				rejectedBy: powerLevelEvent.toEventBase(),
+			});
 		} // If the sender does not match state_key,
 
 		case 'leave': {
@@ -286,7 +305,11 @@ async function isMembershipChangeAllowed(
 
 			// If the sender’s current membership state is not join, reject.
 			if (senderMembership !== 'join') {
-				throw new Error('sender is not join');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'sender is not join',
+					rejectedBy: senderMembershipEvent,
+				});
 			}
 
 			// If the target user’s current membership state is ban, and the sender’s power level is less than the ban level, reject.
@@ -298,7 +321,11 @@ async function isMembershipChangeAllowed(
 			const banLevel = powerLevelEvent.getRequiredPowerForBan();
 
 			if (inviteeMembership === 'ban' && senderPowerLevel < banLevel) {
-				throw new Error('sender power level is less than ban level');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'sender power level is less than ban level',
+					rejectedBy: powerLevelEvent.toEventBase(),
+				});
 			}
 
 			// If the sender’s power level is greater than or equal to the kick level, and the target user’s power level is less than the sender’s power level, allow.
@@ -311,13 +338,21 @@ async function isMembershipChangeAllowed(
 				return;
 			}
 
-			throw new Error('sender power level is less than kick level');
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: membershipEventToCheck,
+				reason: 'sender power level is less than kick level',
+				rejectedBy: powerLevelEvent.toEventBase(),
+			});
 		}
 
 		case 'ban': {
 			// If the sender’s current membership state is not join, reject.
 			if (senderMembership !== 'join') {
-				throw new Error('sender is not join');
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: membershipEventToCheck,
+					reason: 'sender is not join',
+					rejectedBy: senderMembershipEvent,
+				});
 			}
 
 			// If the sender’s power level is greater than or equal to the ban level, and the target user’s power level is less than the sender’s power level, allow.
@@ -391,18 +426,24 @@ export function validatePowerLevelEvent(
 			newUserDefaultPowerLevel &&
 			newUserDefaultPowerLevel > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'new user_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (
 			existingUserDefaultPowerLevel &&
 			existingUserDefaultPowerLevel > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'existing user_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -415,18 +456,24 @@ export function validatePowerLevelEvent(
 			newEventsDefaultValue &&
 			newEventsDefaultValue > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'new events_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (
 			existingEventsDefaultValue &&
 			existingEventsDefaultValue > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'existing events_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -439,18 +486,24 @@ export function validatePowerLevelEvent(
 			newStateDefaultValue &&
 			newStateDefaultValue > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'new state_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (
 			existingStateDefaultValue &&
 			existingStateDefaultValue > senderCurrentPowerLevel
 		) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason:
+					'existing state_default power level is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -460,15 +513,19 @@ export function validatePowerLevelEvent(
 	// for ban
 	if (existingBanValue !== newBanValue) {
 		if (newBanValue && newBanValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'new power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (existingBanValue && existingBanValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'existing power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -478,15 +535,19 @@ export function validatePowerLevelEvent(
 	// for kick
 	if (existingKickValue !== newKickValue) {
 		if (newKickValue && newKickValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'new power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (existingKickValue && existingKickValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'existing power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -496,15 +557,19 @@ export function validatePowerLevelEvent(
 
 	if (existingRedactValue !== newRedactValue) {
 		if (newRedactValue && newRedactValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'new power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (existingRedactValue && existingRedactValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'existing power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -514,15 +579,19 @@ export function validatePowerLevelEvent(
 
 	if (existingInviteValue !== newInviteValue) {
 		if (newInviteValue && newInviteValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'new power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'new power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 
 		if (existingInviteValue && existingInviteValue > senderCurrentPowerLevel) {
-			throw new Error(
-				'existing power level value is greater than sender power level',
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: powerLevelEvent.toEventBase()!,
+				reason: 'existing power level value is greater than sender power level',
+				rejectedBy: existingPowerLevel.toEventBase(),
+			});
 		}
 	}
 
@@ -545,9 +614,12 @@ export function validatePowerLevelEvent(
 				existingPowerLevelValue &&
 				existingPowerLevelValue > senderCurrentPowerLevel
 			) {
-				throw new Error(
-					'existing power level value is greater than sender power level',
-				);
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: powerLevelEvent.toEventBase()!,
+					reason:
+						'existing power level value is greater than sender power level',
+					rejectedBy: existingPowerLevel.toEventBase(),
+				});
 			}
 		}
 	}
@@ -565,9 +637,11 @@ export function validatePowerLevelEvent(
 			// changed or added
 			// If the new value is greater than the sender’s current power level, reject.
 			if (newPowerLevelValue && newPowerLevelValue > senderCurrentPowerLevel) {
-				throw new Error(
-					'new power level value is greater than sender power level',
-				);
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: powerLevelEvent.toEventBase()!,
+					reason: 'new power level value is greater than sender power level',
+					rejectedBy: existingPowerLevel.toEventBase(),
+				});
 			}
 		}
 	}
@@ -589,9 +663,12 @@ export function validatePowerLevelEvent(
 				existingPowerLevelValue &&
 				existingPowerLevelValue > senderCurrentPowerLevel
 			) {
-				throw new Error(
-					'existing power level value is greater than sender power level',
-				);
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: powerLevelEvent.toEventBase()!,
+					reason:
+						'existing power level value is greater than sender power level',
+					rejectedBy: existingPowerLevel.toEventBase(),
+				});
 			}
 		}
 	}
@@ -609,9 +686,11 @@ export function validatePowerLevelEvent(
 			// changed or added
 			// If the new value is greater than the sender’s current power level, reject.
 			if (newPowerLevelValue && newPowerLevelValue > senderCurrentPowerLevel) {
-				throw new Error(
-					'new power level value is greater than sender power level',
-				);
+				throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+					rejectedEvent: powerLevelEvent.toEventBase()!,
+					reason: 'new power level value is greater than sender power level',
+					rejectedBy: existingPowerLevel.toEventBase(),
+				});
 			}
 		}
 	}
@@ -623,12 +702,10 @@ export function checkEventAuthWithoutState(
 ) {
 	if (event.isCreateEvent()) {
 		if (authEvents.length > 0) {
-			throw new StateResolverAuthorizationError(
-				'm.room.create event has auth_events',
-				{
-					eventFailed: event,
-				},
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: event,
+				reason: 'm.room.create event has auth_events',
+			});
 		}
 
 		return isCreateAllowed(event);
@@ -653,36 +730,30 @@ export function checkEventAuthWithoutState(
 	for (const authEvent of authEvents) {
 		// if rejected, reject this event
 		if (authEvent.rejected) {
-			throw new StateResolverAuthorizationError(
-				`auth event ${authEvent.eventId} rejected`,
-				{
-					eventFailed: event,
-					reason: authEvent,
-				},
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: event,
+				reason: 'auth event required to authorize this event was rejected',
+				rejectedBy: authEvent,
+			});
 		}
 
 		const stateKey = authEvent.getUniqueStateIdentifier();
 
 		// if this is not neeede, throw
 		if (!stateKeysNeeded.has(stateKey)) {
-			throw new StateResolverAuthorizationError(
-				`excess auth event ${authEvent.eventId} with type ${authEvent.type} state_key ${authEvent.stateKey}`,
-				{
-					eventFailed: event,
-					reason: authEvent,
-				},
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: event,
+				reason: 'excess auth event',
+				rejectedBy: authEvent,
+			});
 		}
 
 		if (authEventStateMap.has(stateKey)) {
-			throw new StateResolverAuthorizationError(
-				`duplicate auth event ${authEvent.eventId} with type ${authEvent.type} state_key ${authEvent.stateKey}`,
-				{
-					eventFailed: event,
-					reason: authEvent,
-				},
-			);
+			throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+				rejectedEvent: event,
+				rejectedBy: authEvent,
+				reason: 'duplicate auth event',
+			});
 		}
 
 		authEventStateMap.set(stateKey, authEvent);
@@ -693,8 +764,9 @@ export function checkEventAuthWithoutState(
 	});
 
 	if (!roomCreateEvent) {
-		throw new StateResolverAuthorizationError('missing m.room.create event', {
-			eventFailed: event,
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			reason: 'missing m.room.create event',
 		});
 	}
 
@@ -718,8 +790,9 @@ export async function checkEventAuthWithState(
 	assert(roomCreateEvent, 'missing m.room.create event');
 
 	if (!roomCreateEvent.isCreateEvent()) {
-		throw new StateResolverAuthorizationError('m.room.create event not found', {
-			eventFailed: event,
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			reason: 'm.room.create event not found',
 		});
 	}
 
@@ -728,13 +801,11 @@ export async function checkEventAuthWithState(
 		roomCreateEvent.getContent()['m.federate'] === false &&
 		event.origin !== roomCreateEvent.origin
 	) {
-		throw new StateResolverAuthorizationError(
-			'm.federate is false and sender domain does not match',
-			{
-				eventFailed: event,
-				reason: roomCreateEvent,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			rejectedBy: roomCreateEvent,
+			reason: 'm.federate is false and sender domain does not match',
+		});
 	}
 
 	if (event.isAliasEvent()) {
@@ -751,25 +822,21 @@ export async function checkEventAuthWithState(
 		state_key: event.sender,
 	});
 	if (senderMembership?.getMembership() !== 'join') {
-		throw new StateResolverAuthorizationError(
-			"sender's membership is not join",
-			{
-				eventFailed: event,
-				reason: senderMembership,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			reason: "sender's membership is not join",
+			rejectedBy: senderMembership,
+		});
 	}
 
 	// If type is m.room.third_party_invite:
 	// @ts-ignore the pdu union doesn't have this type TODO: add
 	if (event.type === 'm.room.third_party_invite') {
 		console.warn('third_party_invite not implemented');
-		throw new StateResolverAuthorizationError(
-			'third_party_invite not implemented',
-			{
-				eventFailed: event,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.NotImplemented, {
+			rejectedEvent: event,
+			reason: 'third_party_invite not implemented',
+		});
 	}
 
 	const existingPowerLevelEvent = getStateByMapKey(state, {
@@ -791,24 +858,19 @@ export async function checkEventAuthWithState(
 	);
 
 	if (userPowerLevel < eventRequiredPowerLevel) {
-		throw new StateResolverAuthorizationError(
-			'user power level is less than event required power level',
-			{
-				eventFailed: event,
-				reason: powerLevelEvent.toEventBase(),
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			rejectedBy: powerLevelEvent.toEventBase(),
+			reason: `user power level ${userPowerLevel} is less than event required power level ${eventRequiredPowerLevel}`,
+		});
 	}
 
 	// If the event has a state_key that starts with an @ and does not match the sender, reject.
 	if (event.stateKey?.startsWith('@') && event.stateKey !== event.sender) {
-		throw new StateResolverAuthorizationError(
-			'event state key does not match sender',
-			{
-				eventFailed: event,
-				reason: event,
-			},
-		);
+		throw new StateResolverAuthorizationError(RejectCodes.AuthError, {
+			rejectedEvent: event,
+			reason: 'event state_key does not match sender',
+		});
 	}
 
 	// If type is m.room.power_levels:

--- a/packages/room/src/index.ts
+++ b/packages/room/src/index.ts
@@ -2,6 +2,7 @@ export {
 	checkEventAuthWithState,
 	checkEventAuthWithoutState,
 } from './authorizartion-rules/rules';
+export * from './authorizartion-rules/errors';
 export { resolveStateV2Plus } from './state_resolution/definitions/algorithm/v2';
 export * from './manager/factory';
 export * from './manager/event-wrapper';

--- a/packages/room/src/manager/event-wrapper.ts
+++ b/packages/room/src/manager/event-wrapper.ts
@@ -3,6 +3,7 @@ import {
 	encodeCanonicalJson,
 	toUnpaddedBase64,
 } from '@rocket.chat/federation-crypto';
+import { RejectCode } from '../authorizartion-rules/errors';
 import {
 	type EventStore,
 	getStateMapKey,
@@ -44,7 +45,11 @@ export abstract class PersistentEventBase<
 	Version extends RoomVersion = RoomVersion,
 	Type extends PduType = PduType,
 > {
-	private _rejectedReason?: string;
+	public rejectCode = '';
+
+	public rejectReason = '';
+
+	public rejectedBy = '' as EventID;
 
 	private signatures: Signature = {};
 
@@ -409,15 +414,13 @@ export abstract class PersistentEventBase<
 	}
 
 	get rejected() {
-		return this._rejectedReason !== undefined;
+		return this.rejectCode !== '';
 	}
 
-	reject(reason: string) {
-		this._rejectedReason = reason;
-	}
-
-	get rejectedReason() {
-		return this._rejectedReason;
+	reject(code: RejectCode, reason: string, rejectedBy?: EventID) {
+		this.rejectCode = code;
+		this.rejectReason = reason;
+		if (rejectedBy) this.rejectedBy = rejectedBy;
 	}
 
 	addPrevEvents(events: PersistentEventBase<Version>[]) {
@@ -439,6 +442,16 @@ export abstract class PersistentEventBase<
 		};
 
 		return this;
+	}
+
+	toStrippedJson() {
+		return encodeCanonicalJson({
+			eventId: this.eventId,
+			type: this.type,
+			roomId: this.roomId,
+			sender: this.sender,
+			stateKey: this.stateKey,
+		});
 	}
 }
 export type { EventStore };

--- a/packages/room/src/manager/event-wrapper.ts
+++ b/packages/room/src/manager/event-wrapper.ts
@@ -3,7 +3,7 @@ import {
 	encodeCanonicalJson,
 	toUnpaddedBase64,
 } from '@rocket.chat/federation-crypto';
-import { RejectCode } from '../authorizartion-rules/errors';
+import type { RejectCode } from '../authorizartion-rules/errors';
 import {
 	type EventStore,
 	getStateMapKey,

--- a/packages/room/src/manager/factory.ts
+++ b/packages/room/src/manager/factory.ts
@@ -52,7 +52,7 @@ export class PersistentEventFactory {
 
 	static createFromRawEvent<Type extends PduType>(
 		event: PduWithHashesAndSignaturesOptional,
-		roomVersion: string,
+		roomVersion: RoomVersion,
 	): PersistentEventBase<RoomVersion, Type> {
 		if (!PersistentEventFactory.isSupportedRoomVersion(roomVersion)) {
 			throw new Error(`Room version ${roomVersion} is not supported`);


### PR DESCRIPTION
required for further prs where we use these to save rejections
example log
```
event not allowed StateResolverAuthorizationError: auth_error: {"eventId":"$D0DBXj6yXAG5xxwRodZonN6iZ8S-lMY0gV_euS_YQnM","roomId":"!test:example.com","sender":"@evelyn:example.com","stateKey":"@evelyn:example.com","type":"m.room.member"} failed authorization check against auth event {"eventId":"$zdg24nzX8zbXL51a9UfUhK6HURmoCoFsD22hwAfdSGI","roomId":"!test:example.com","sender":"@alice:example.com","stateKey":"","type":"m.room.join_rules"}: join_rule is invite but membership is not invite or join
     reason: "join_rule is invite but membership is not invite or join",
 rejectedBy: "$zdg24nzX8zbXL51a9UfUhK6HURmoCoFsD22hwAfdSGI",
       code: "auth_error"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced structured authorization errors with codes and clearer messages, improving visibility into why events are rejected.
  - Exposed error codes for downstream consumers to handle rejections more reliably.

- Bug Fixes
  - Corrected usage of rejection fields to ensure accurate error reporting across invites, joins, messages, and state handling.

- Refactor
  - Standardized rejection handling across services and state resolution, continuing processing on known authorization failures while halting on unknown errors.
  - Tightened typings and streamlined unused dependencies for improved stability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->