### PR TITLE
chore: add incomplete type for rich messages

### DIFF
--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -152,6 +152,17 @@ export type HomeserverEventSignatures = {
 							origin_server_ts: number;
 						};
 						is_falling_back?: boolean;
+				  }
+				| {
+						// SPEC: Though rich replies form a relationship to another event, they do not use rel_type to create this relationship.
+						// Instead, a subkey named m.in_reply_to is used to describe the reply’s relationship,
+
+						// rich {"body":"quote","m.mentions":{},"m.relates_to":{"is_falling_back":false,"m.in_reply_to":{"event_id":"$0vkvf2Ha_FdWe3zVaoDw3X15VCyZIZRYrHQXuoZDURQ"}},"msgtype":"m.text"}
+
+						'm.in_reply_to'?: {
+							event_id: EventID;
+						};
+						is_falling_back?: boolean;
 				  };
 			'm.new_content'?: {
 				body: string;

--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -159,7 +159,7 @@ export type HomeserverEventSignatures = {
 
 						// rich {"body":"quote","m.mentions":{},"m.relates_to":{"is_falling_back":false,"m.in_reply_to":{"event_id":"$0vkvf2Ha_FdWe3zVaoDw3X15VCyZIZRYrHQXuoZDURQ"}},"msgtype":"m.text"}
 
-						'm.in_reply_to'?: {
+						'm.in_reply_to': {
 							event_id: EventID;
 						};
 						is_falling_back?: boolean;


### PR DESCRIPTION
[FDR-165]

[FDR-165]: https://rocketchat.atlassian.net/browse/FDR-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/RocketChat/Rocket.Chat/pull/37077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reply handling in messages with support for rich replies using a nested “in-reply-to” structure.
  * Added optional fallback indicator to better manage legacy reply behavior.

* **Bug Fixes**
  * Aligns reply representation with the official spec to reduce inconsistencies in how replies are parsed and displayed.

* **Chores**
  * Updated event content schema to support nested reply metadata, paving the way for more reliable threading and reply rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->