### PR TITLE
fix: failing requests to hostnames with ipv6

### DIFF
--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -147,7 +147,8 @@ export async function fetch<T>(
 	).hostname;
 
 	const requestParams: RequestOptions = {
-		host: url.hostname, // IP
+		// for ipv6 remove square brackets as they come due to url standard
+		host: url.hostname.replace(/^\[|\]$/g, ''), // IP
 		port: url.port,
 		method: options.method,
 		path: url.pathname + url.search,


### PR DESCRIPTION
remove square brackets from ipv6 hostnames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of IPv6 addresses in outgoing HTTPS requests by normalizing the Host header (removing surrounding brackets).
  - Improves compatibility with IPv6 servers, proxies, and load balancers that enforce strict header formats.
  - Resolves occasional connection failures or header validation errors when targeting IPv6 endpoints.
  - No impact on IPv4 or domain-based requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->