### PR TITLE
chore: allow using v4 over v6 for resolved dns results

### DIFF
--- a/packages/federation-sdk/src/server-discovery/_resolver.ts
+++ b/packages/federation-sdk/src/server-discovery/_resolver.ts
@@ -1,7 +1,10 @@
+import type { LookupAllOptions } from 'node:dns';
 import { Resolver, lookup } from 'node:dns/promises';
 
 // no caching, depends on system
 class _Resolver extends Resolver {
+	private lookupOrder: LookupAllOptions['order'] = 'ipv6first';
+
 	constructor() {
 		super();
 
@@ -12,6 +15,19 @@ class _Resolver extends Resolver {
 
 			this.setServers(servers);
 		}
+
+		// spec says v6 first, but there shouldn't be a case where a and aaaa records point to different services. if does, not an application problem.
+		// for systems with no v6 support this still lets allow a fallback to v4 first. without needing to add system level dns filter.
+		// as long as the name has an a record, should be able to communicate.
+		const order = process.env
+			.HOMESERVER_CONFIG_DNS_LOOKUP_ORDER as typeof this.lookupOrder;
+		if (
+			order === 'ipv4first' ||
+			order === 'ipv6first' ||
+			order === 'verbatim'
+		) {
+			this.lookupOrder = order;
+		}
 	}
 
 	// The implementation uses an operating system facility that can associate names with addresses and vice versa
@@ -20,7 +36,7 @@ class _Resolver extends Resolver {
 		const result = await lookup(hostname, {
 			all: true,
 			family: 0,
-			order: 'ipv6first',
+			order: this.lookupOrder,
 		});
 
 		return result.map((r) => r.address);

--- a/packages/federation-sdk/src/server-discovery/_resolver.ts
+++ b/packages/federation-sdk/src/server-discovery/_resolver.ts
@@ -19,8 +19,7 @@ class _Resolver extends Resolver {
 		// spec says v6 first, but there shouldn't be a case where a and aaaa records point to different services. if does, not an application problem.
 		// for systems with no v6 support this still lets allow a fallback to v4 first. without needing to add system level dns filter.
 		// as long as the name has an a record, should be able to communicate.
-		const order = process.env
-			.HOMESERVER_CONFIG_DNS_LOOKUP_ORDER as typeof this.lookupOrder;
+		const order = process.env.HOMESERVER_CONFIG_DNS_LOOKUP_ORDER;
 		if (
 			order === 'ipv4first' ||
 			order === 'ipv6first' ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable DNS lookup order via environment variable to improve connectivity across diverse network environments.
  * Supports choosing IPv4-first, IPv6-first, or verbatim resolution; defaults remain unchanged when not configured or set to an unsupported value.
  * Enables administrators to tailor network resolution behavior without code changes, potentially reducing connection delays and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->