### PR TITLE
fix: emit member events outside pdu process

### DIFF
--- a/packages/core/src/events/eventBase.ts
+++ b/packages/core/src/events/eventBase.ts
@@ -37,6 +37,12 @@ export type RedactedEvent = EventBase & {
 	type: 'm.room.redaction';
 };
 
+export const isCreateEvent = (
+	event: Pdu,
+): event is PduForType<'m.room.create'> & {} => {
+	return event.type === 'm.room.create';
+};
+
 export const isRedactedEvent = (
 	event: Pdu,
 ): event is PduForType<'m.room.redaction'> => {

--- a/packages/core/src/events/eventBase.ts
+++ b/packages/core/src/events/eventBase.ts
@@ -37,12 +37,6 @@ export type RedactedEvent = EventBase & {
 	type: 'm.room.redaction';
 };
 
-export const isCreateEvent = (
-	event: Pdu,
-): event is PduForType<'m.room.create'> & {} => {
-	return event.type === 'm.room.create';
-};
-
 export const isRedactedEvent = (
 	event: Pdu,
 ): event is PduForType<'m.room.redaction'> => {

--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -1,11 +1,7 @@
 import 'reflect-metadata';
 
 import type { Emitter } from '@rocket.chat/emitter';
-import type {
-	EventStagingStore,
-	Membership,
-	MessageType,
-} from '@rocket.chat/federation-core';
+import type { EventStagingStore } from '@rocket.chat/federation-core';
 import type {
 	EventID,
 	EventStore,
@@ -90,6 +86,11 @@ export type HomeserverEventSignatures = {
 	'homeserver.matrix.encrypted': {
 		event_id: EventID;
 		event: PduForType<'m.room.encrypted'>;
+	};
+	'homeserver.matrix.room.create': {
+		room_id: string;
+		event: PduForType<'m.room.create'>;
+		event_id: EventID;
 	};
 	'homeserver.matrix.message': {
 		event_id: EventID;

--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -88,7 +88,6 @@ export type HomeserverEventSignatures = {
 		event: PduForType<'m.room.encrypted'>;
 	};
 	'homeserver.matrix.room.create': {
-		room_id: string;
 		event: PduForType<'m.room.create'>;
 		event_id: EventID;
 	};

--- a/packages/federation-sdk/src/services/invite.service.ts
+++ b/packages/federation-sdk/src/services/invite.service.ts
@@ -12,13 +12,14 @@ import {
 import { singleton } from 'tsyringe';
 import { ConfigService } from './config.service';
 import { EventAuthorizationService } from './event-authorization.service';
+import { EventEmitterService } from './event-emitter.service';
+import { EventService } from './event.service';
 import { FederationService } from './federation.service';
 import {
+	RoomInfoNotReadyError,
 	StateService,
 	UnknownRoomError,
-	RoomInfoNotReadyError,
 } from './state.service';
-import { EventEmitterService } from './event-emitter.service';
 // TODO: Have better (detailed/specific) event input type
 export type ProcessInviteEvent = {
 	event: EventBase;

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -8,7 +8,6 @@ import {
 	roomPowerLevelsEvent,
 } from '@rocket.chat/federation-core';
 import { delay, inject, singleton } from 'tsyringe';
-import { FederationService } from './federation.service';
 
 import {
 	ForbiddenError,
@@ -34,11 +33,17 @@ import { EventStagingRepository } from '../repositories/event-staging.repository
 import { EventRepository } from '../repositories/event.repository';
 import { RoomRepository } from '../repositories/room.repository';
 import { ConfigService } from './config.service';
+import { EventAuthorizationService } from './event-authorization.service';
 import { EventEmitterService } from './event-emitter.service';
 import { EventFetcherService } from './event-fetcher.service';
 import { EventService } from './event.service';
+import { FederationService } from './federation.service';
 import { InviteService } from './invite.service';
-import { StateService, UnknownRoomError } from './state.service';
+import {
+	RoomInfoNotReadyError,
+	StateService,
+	UnknownRoomError,
+} from './state.service';
 
 @singleton()
 export class RoomService {

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -1274,6 +1274,7 @@ export class RoomService {
 
 		await this.roomRepository.markRoomAsDeleted(roomId, event.eventId);
 
+		// TODO: check if all sendEventToAllServersInRoom should be followed by an emitter
 		void this.federationService.sendEventToAllServersInRoom(event);
 
 		logger.info(`Successfully marked room ${roomId} as tombstone`);

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -57,6 +57,7 @@ export class RoomService {
 		private readonly eventRepository: EventRepository,
 		@inject(delay(() => EventStagingRepository))
 		private readonly eventStagingRepository: EventStagingRepository,
+		private readonly emitterService: EventEmitterService,
 	) {}
 
 	private validatePowerLevelChange(
@@ -889,6 +890,11 @@ export class RoomService {
 			}
 
 			void federationService.sendEventToAllServersInRoom(membershipEvent);
+
+			this.emitterService.emit('homeserver.matrix.membership', {
+				event_id: membershipEvent.eventId,
+				event: membershipEvent.event,
+			});
 
 			return membershipEvent.eventId;
 		}

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -8,7 +8,6 @@ import { singleton } from 'tsyringe';
 import {
 	MessageType,
 	createLogger,
-	isCreateEvent,
 	isRedactedEvent,
 } from '@rocket.chat/federation-core';
 import {
@@ -275,7 +274,7 @@ export class StagingAreaService {
 		} = event;
 
 		switch (true) {
-			case isCreateEvent(event.event):
+			case event.event.type === 'm.room.create':
 				{
 					this.eventEmitterService.emit('homeserver.matrix.room.create', {
 						room_id: roomId,

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -268,16 +268,12 @@ export class StagingAreaService {
 	private async processNotificationStage(event: EventStagingStore) {
 		this.logger.debug(`Notifying clients about event ${event._id}`);
 
-		const {
-			_id: eventId,
-			event: { room_id: roomId },
-		} = event;
+		const { _id: eventId, roomId } = event;
 
 		switch (true) {
 			case event.event.type === 'm.room.create':
 				{
 					this.eventEmitterService.emit('homeserver.matrix.room.create', {
-						room_id: roomId,
 						event_id: eventId,
 						event: event.event,
 					});

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -8,6 +8,7 @@ import { singleton } from 'tsyringe';
 import {
 	MessageType,
 	createLogger,
+	isCreateEvent,
 	isRedactedEvent,
 } from '@rocket.chat/federation-core';
 import {
@@ -274,6 +275,15 @@ export class StagingAreaService {
 		} = event;
 
 		switch (true) {
+			case isCreateEvent(event.event):
+				{
+					this.eventEmitterService.emit('homeserver.matrix.room.create', {
+						room_id: roomId,
+						event_id: eventId,
+						event: event.event,
+					});
+				}
+				break;
 			case event.event.type === 'm.room.message':
 				this.eventEmitterService.emit('homeserver.matrix.message', {
 					event_id: eventId,

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -58,6 +58,13 @@ export class PartialStateResolutionError extends Error {
 export class UnknownRoomError extends Error {
 	constructor(roomId: RoomID) {
 		super(`Room ${roomId} does not exist`);
+		this.name = 'UnknownRoomError';
+	}
+}
+export class RoomInfoNotReadyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'RoomInfoNotReadyError';
 	}
 }
 
@@ -82,7 +89,9 @@ export class StateService {
 				'm.room.create',
 			)) ?? {};
 		if (event?.type !== 'm.room.create') {
-			throw new Error('Create event mapping not found for room information');
+			throw new RoomInfoNotReadyError(
+				'Create event mapping not found for room information',
+			);
 		}
 
 		if (!stateId) {


### PR DESCRIPTION
As per [FB-52](https://rocketchat.atlassian.net/browse/FB-52), this PR fixes an issue where remote servers fail to join RC-originated rooms because membership events for local RC users were not being emitted at the correct time, preventing those events from being saved into our state.

When a room is created on RC and local users A and B join before a remote user is invited, their membership events were only emitted during the transaction flow. They were not persisted in a way that backfill or later federation queries could retrieve. As a result, remote homeservers (e.g., Synapse) receive an invite referencing users for whom they have no membership state, eventually failing with:
```
502 - Failed to make_join via any server
```

Fix: Membership events are now emitted immediately after processing invites/joins, outside of the PDU transaction-only path. This ensures the events are correctly stored in our state, allowing backfill to include them and enabling remote servers to obtain the complete membership graph required to successfully evaluate and join the room.

## Release Notes

* **New Features**
  * Added support for room creation events in federation event handling.

* **Improvements**
  * Enhanced event emission for membership and room state changes.
  * Improved error handling and reporting for room information readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[FB-52]: https://rocketchat.atlassian.net/browse/FB-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ