### PR TITLE
chore: changed default DNS resolution to ipv4first

### DIFF
--- a/packages/federation-sdk/src/server-discovery/_resolver.ts
+++ b/packages/federation-sdk/src/server-discovery/_resolver.ts
@@ -3,7 +3,7 @@ import { Resolver, lookup } from 'node:dns/promises';
 
 // no caching, depends on system
 class _Resolver extends Resolver {
-	private lookupOrder: LookupAllOptions['order'] = 'ipv6first';
+	private lookupOrder: LookupAllOptions['order'] = 'ipv4first';
 
 	constructor() {
 		super();


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/FDR-196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - DNS resolution now prioritizes IPv4 addresses by default when both IPv4 and IPv6 records are present, changing the order of addresses attempted during multi-address lookups. Environment variable overrides for lookup order remain supported and unchanged. No public APIs were modified, but connection paths in dual-stack setups may differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->