### PR TITLE
chore: allow displayname and avatar_url as null of member event

### DIFF
--- a/packages/federation-sdk/src/utils/event-schemas.ts
+++ b/packages/federation-sdk/src/utils/event-schemas.ts
@@ -45,8 +45,8 @@ const memberEventSchema = baseEventSchema.extend({
 	content: z
 		.object({
 			membership: z.enum(['invite', 'join', 'leave', 'ban', 'knock']),
-			displayname: z.string().optional(),
-			avatar_url: z.string().optional(),
+			displayname: z.string().optional().nullable(),
+			avatar_url: z.string().optional().nullable(),
 		})
 		.and(z.record(z.any())),
 });


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/FDR-201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved federation compatibility by accepting null values for member display name and avatar in membership events. This prevents validation errors when remote servers send nulls, ensuring smoother room joins, profile updates, and sync operations. Users without a display name or avatar are now handled gracefully, reducing error logs and improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->