### PR TITLE
chore: export EventStore, PduType and PduForType from federation-sdk

### DIFF
--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -17,12 +17,16 @@ import { StateService } from './services/state.service';
 import { WellKnownService } from './services/well-known.service';
 
 export type {
+	Pdu,
+	PduForType,
 	PduMembershipEventContent,
+	PduType,
 	PersistentEventBase,
 	RoomVersion,
 	EventID,
 } from '@rocket.chat/federation-room';
 export type {
+	EventStore,
 	FileMessageType,
 	PresenceState,
 	FileMessageContent,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded the federation SDK’s public export surface with additional type aliases to improve TypeScript ergonomics for integrators and plugin authors.
  - Enables easier consumption of federation-related APIs with better IDE autocomplete and static typing.
  - No changes to runtime behavior or error handling; existing functionality remains unaffected.
  - No migration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->