### PR TITLE
fix: prevent add prev_event or auth_events if the initial events are already informed

### DIFF
--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -414,10 +414,9 @@ export class StateService {
 			event,
 			roomVersion,
 		);
-
 		await Promise.all([
-			this.addAuthEvents(instance),
-			this.addPrevEvents(instance),
+			instance.event.auth_events.length === 0 && this.addAuthEvents(instance),
+			instance.event.prev_events.length === 0 && this.addPrevEvents(instance),
 		]);
 		await this.signEvent(instance);
 


### PR DESCRIPTION
…lready informed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate or unintended authorization and previous events, improving event integrity and timeline accuracy.
  * Increased reliability of event ordering and depth calculations in rooms.

* **Refactor**
  * Reworked internal event tracking to use dedicated sets, reducing side effects and making updates safer.
  * Optimized event building to skip unnecessary processing when related events already exist, improving performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->