### PR TITLE
chore: memoize server discovery for 1 hour

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "homeserver",
       "dependencies": {
         "dotenv": "^16.5.0",
+        "memoize": "^10.1.0",
         "reflect-metadata": "^0.2.2",
         "rollup-plugin-dts": "^6.2.3",
         "tsyringe": "^4.10.0",
@@ -52,7 +53,7 @@
     },
     "packages/federation-sdk": {
       "name": "@rocket.chat/federation-sdk",
-      "version": "0.1.13",
+      "version": "0.1.19",
       "dependencies": {
         "@rocket.chat/emitter": "^0.31.25",
         "@rocket.chat/federation-core": "workspace:*",
@@ -390,6 +391,8 @@
     "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "memoize": ["memoize@10.1.0", "", { "dependencies": { "mimic-function": "^5.0.1" } }, "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg=="],
 
     "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	"workspaces": ["packages/*"],
 	"dependencies": {
 		"dotenv": "^16.5.0",
+		"memoize": "^10.1.0",
 		"reflect-metadata": "^0.2.2",
 		"rollup-plugin-dts": "^6.2.3",
 		"tsyringe": "^4.10.0",

--- a/packages/federation-sdk/src/server-discovery/discovery.spec.ts
+++ b/packages/federation-sdk/src/server-discovery/discovery.spec.ts
@@ -73,8 +73,8 @@ function spec_2__1(): [INPUT[], OUTPUT[]] {
 function spec_2__2(): [INPUT[], OUTPUT[]] {
 	stubs.resolveHostname.resolves('[::1]');
 	return [
-		['example.com:45'],
-		[['https://[::1]:45' as const, { Host: 'example.com:45' }]],
+		['example_spec_2__2.com:45'],
+		[['https://[::1]:45' as const, { Host: 'example_spec_2__2.com:45' }]],
 	];
 }
 
@@ -82,7 +82,7 @@ function spec_2__2(): [INPUT[], OUTPUT[]] {
 // If <delegated_hostname> is an IP literal, then that IP address should be used together with the <delegated_port> or 8448 if no port is provided. The target server must present a valid TLS certificate for the IP address. Requests must be made with a Host header containing the IP address, including the port if one was provided.
 function spec_3_1__1(): [INPUT[], OUTPUT[]] {
 	// If the hostname is not an IP literal and no port is provided
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_1__1.com'];
 
 	stubs.resolveHostname.resolves('11.0.0.1');
 
@@ -99,7 +99,7 @@ function spec_3_1__1(): [INPUT[], OUTPUT[]] {
 }
 
 function spec_3_1__2(): [INPUT[], OUTPUT[]] {
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_1__2.com'];
 
 	stubs.resolveHostname.resolves('[::1]');
 
@@ -114,68 +114,77 @@ function spec_3_1__2(): [INPUT[], OUTPUT[]] {
 /* 3.2. If <delegated_hostname> is not an IP literal, and <delegated_port> is present, an IP address is discovered by looking up CNAME, AAAA or A records for <delegated_hostname>. The resulting IP address is used, alongside the <delegated_port>. Requests must be made with a Host header of <delegated_hostname>:<delegated_port>. The target server must present a valid certificate for <delegated_hostname>.
  */
 function spec_3_2(): [INPUT[], OUTPUT[]] {
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_2.com'];
 
 	stubs.resolveHostname.reset();
 
 	// for some reason onFirstCall and onSecondCall is not working
 	stubs.resolveHostname.callsFake((hostname: string) => {
-		if (hostname === 'example.com') {
+		if (hostname === 'example_spec_3_2.com') {
 			return Promise.resolve('11.0.0.1');
 		}
 
-		if (hostname === 'example2.com') {
+		if (hostname === 'example2_spec_3_2.com') {
 			return Promise.resolve('[::1]');
 		}
 	});
 
 	stubs.fetch.resolves({
 		ok: true,
-		json: () => Promise.resolve({ 'm.server': 'example2.com:45' }), // delegatedPort is present
+		json: () => Promise.resolve({ 'm.server': 'example2_spec_3_2.com:45' }), // delegatedPort is present
 	});
 
-	return [inputs, [['https://[::1]:45' as const, { Host: 'example2.com:45' }]]];
+	return [
+		inputs,
+		[['https://[::1]:45' as const, { Host: 'example2_spec_3_2.com:45' }]],
+	];
 }
 
 /* If <delegated_hostname> is not an IP literal and no <delegated_port> is present, an SRV record is looked up for _matrix-fed._tcp.<delegated_hostname>. This may result in another hostname (to be resolved using AAAA or A records) and port. Requests should be made to the resolved IP address and port with a Host header containing the <delegated_hostname>. The target server must present a valid certificate for <delegated_hostname>.*/
 function spec_3_3__1(): [INPUT[], OUTPUT[]] {
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_3__1.com'];
 
 	stubs.resolveHostname.resolves('11.0.0.1');
 
 	stubs.fetch.resolves({
 		ok: true,
-		json: () => Promise.resolve({ 'm.server': 'example2.com' }), // no delegatedPort is present, delegatedHostname is present and not ip
+		json: () => Promise.resolve({ 'm.server': 'example2_spec_3_3__1.com' }), // no delegatedPort is present, delegatedHostname is present and not ip
 	});
 
 	stubs.resolveSrv.resolves([{ name: '::1', port: 45 }]);
 
-	return [inputs, [['https://[::1]:45' as const, { Host: 'example2.com' }]]];
+	return [
+		inputs,
+		[['https://[::1]:45' as const, { Host: 'example2_spec_3_3__1.com' }]],
+	];
 }
 
 function spec_3_3__2(): [INPUT[], OUTPUT[]] {
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_3__2.com'];
 
 	stubs.resolveHostname.callsFake((name) => {
-		if (name === 'exmaple.com') return '11.0.0.1';
+		if (name === 'exmaple_spec_3_3__2.com') return '11.0.0.1';
 
-		if (name === 'example3.com') return '[::1]';
+		if (name === 'example3_spec_3_3__2.com') return '[::1]';
 	});
 
 	stubs.fetch.resolves({
 		ok: true,
-		json: () => Promise.resolve({ 'm.server': 'example2.com' }), // no delegatedPort is present, delegatedHostname is present and not ip
+		json: () => Promise.resolve({ 'm.server': 'example2_spec_3_3__2.com' }), // no delegatedPort is present, delegatedHostname is present and not ip
 	});
 
-	stubs.resolveSrv.resolves([{ name: 'example3.com', port: 45 }]); // another hostname
+	stubs.resolveSrv.resolves([{ name: 'example3_spec_3_3__2.com', port: 45 }]); // another hostname
 	// now should do another resolveHostname
 
-	return [inputs, [['https://[::1]:45' as const, { Host: 'example2.com' }]]];
+	return [
+		inputs,
+		[['https://[::1]:45' as const, { Host: 'example2_spec_3_3__2.com' }]],
+	];
 }
 
 /* If the /.well-known request returned an error response, and no SRV records were found, an IP address is resolved using CNAME, AAAA and A records. Requests are made to the resolved IP address using port 8448 and a Host header containing the <hostname>. The target server must present a valid certificate for <hostname>. */
 function spec_3_4__1(): [INPUT[], OUTPUT[]] {
-	const inputs = ['example.com'];
+	const inputs = ['example_spec_3_4__1.com'];
 
 	stubs.resolveHostname.resolves('11.0.0.1');
 
@@ -189,7 +198,7 @@ function spec_3_4__1(): [INPUT[], OUTPUT[]] {
 
 	return [
 		inputs,
-		[['https://11.0.0.1:8448' as const, { Host: 'example.com' }]],
+		[['https://11.0.0.1:8448' as const, { Host: 'example_spec_3_4__1.com' }]],
 	];
 }
 


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/FDR-203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added caching for homeserver discovery results, reducing repeated lookups and network requests. Default cache duration is 1 hour and can be configured via environment variable.

- Performance
  - Faster repeated server discovery with memoized results, improving responsiveness under load.

- Chores
  - Added a new runtime dependency to support caching.

- Tests
  - Updated test fixtures and expectations to align with the new discovery behavior and domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->