### PR TITLE
feat: add support to encrypted messages

### DIFF
--- a/packages/federation-sdk/src/repositories/event.repository.ts
+++ b/packages/federation-sdk/src/repositories/event.repository.ts
@@ -75,6 +75,7 @@ export class EventRepository {
 			case 'm.reaction':
 			case 'm.room.name':
 			case 'm.room.message':
+			case 'm.room.encrypted':
 			case 'm.room.member':
 			case 'm.room.power_levels':
 			case 'm.room.topic':

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -234,6 +234,32 @@ export class StagingAreaService {
 					},
 				});
 				break;
+			case event.event.type === 'm.room.encrypted':
+				this.eventEmitterService.emit('homeserver.matrix.encrypted', {
+					event_id: eventId,
+					event: event.event,
+					room_id: roomId,
+					sender: event.event.sender,
+					origin_server_ts: event.event.origin_server_ts,
+					content: {
+						...event.event.content,
+						'm.relates_to': event.event.content?.['m.relates_to'] as
+							| {
+									rel_type: 'm.replace';
+									event_id: EventID;
+							  }
+							| {
+									rel_type: 'm.annotation';
+									event_id: EventID;
+									key: string;
+							  }
+							| {
+									rel_type: 'm.thread';
+									event_id: EventID;
+							  },
+					},
+				});
+				break;
 			case event.event.type === 'm.reaction': {
 				this.eventEmitterService.emit('homeserver.matrix.reaction', {
 					event_id: eventId,

--- a/packages/room/src/types/v3-11.ts
+++ b/packages/room/src/types/v3-11.ts
@@ -773,6 +773,7 @@ export type PduContent<T extends PduType = PduType> = PduForType<T>['content'];
 export function isTimelineEventType(type: PduType) {
 	return (
 		type === 'm.room.message' ||
+		type === 'm.room.encrypted' ||
 		type === 'm.reaction' ||
 		type === 'm.room.redaction'
 	);


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/FDR-195

Relates to https://github.com/RocketChat/Rocket.Chat/pull/37191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for encrypted room messages throughout the app: processing, authorization checks, timeline handling.
  * Emits a new encrypted-message event with metadata and preserved relation info (edits, reactions, threads).

* **Refactor**
  * Unified relation handling under a single structure shared by message and encrypted content.
  * Reorganized base content schemas to separate timeline relation fields from message-specific fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->