### PR TITLE
chore: limit staging area processing by 10 tries

### DIFF
--- a/packages/core/src/models/event.model.ts
+++ b/packages/core/src/models/event.model.ts
@@ -39,6 +39,7 @@ export interface EventStore<E = Pdu> extends PersistentEventBase<E> {
 
 export interface EventStagingStore extends PersistentEventBase {
 	roomId: string;
+	got: number;
 	from: 'join' | 'transaction';
 }
 

--- a/packages/federation-sdk/src/server-discovery/discovery.ts
+++ b/packages/federation-sdk/src/server-discovery/discovery.ts
@@ -37,7 +37,7 @@ const SERVER_DISCOVERY_CACHE_MAX_AGE =
 		}
 
 		throw new Error('Invalid SERVER_DISCOVERY_CACHE_MAX_AGE value');
-	})(process.env.SERVER_DISCOVERY_CACHE_MAX_AGE) ?? 3_600_000; // default to 1 hour
+	})(process.env.SERVER_DISCOVERY_CACHE_MAX_AGE) ?? 300_000; // default to 5 minutes
 
 // should only be needed if input is from a dns server
 function fix6(addr: string): `[${string}]` {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable maximum event retry limit (env var, default 10).
  - Shorter default server discovery cache (5 minutes) for fresher results.

- Improvements
  - Event processing now prioritizes less-retried, shallower, and older events for fairer handling.
  - Periodic lock refresh during batch processing to reduce timeouts.
  - More resilient error handling with clearer logging and postponement behavior.
  - Improved indexing to speed selection of next event to process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->