### PR TITLE
fix: remove incorrect authorization stage

### DIFF
--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -124,9 +124,6 @@ export class StagingAreaService {
 					throw new MissingEventsError('Added missing events');
 				}
 
-				if ('from' in event && event.from !== 'join') {
-					await this.processAuthorizationStage(event);
-				}
 				await this.stateService.handlePdu(await toEventBase(event.event));
 				await this.processNotificationStage(event);
 
@@ -246,23 +243,6 @@ export class StagingAreaService {
 		}
 
 		return addedMissing;
-	}
-
-	private async processAuthorizationStage(event: EventStagingStore) {
-		this.logger.debug(`Authorizing event ${event._id}`);
-		const authEvents = await this.eventService.getAuthEventIds(
-			event.event.type,
-			{ roomId: event.event.room_id, senderId: event.event.sender },
-		);
-
-		const isAuthorized = await this.eventAuthService.authorizeEvent(
-			event.event,
-			authEvents.map((e) => e.event),
-		);
-
-		if (!isAuthorized) {
-			throw new Error('event authorization failed');
-		}
 	}
 
 	private async processNotificationStage(event: EventStagingStore) {


### PR DESCRIPTION
auth is part of `handlePdu`, as long as events are processed in order, auth check is done there, this method was wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Streamlined event processing to reduce delays in the staging flow.
  * Faster client notifications due to a more direct processing path.

* **Refactor**
  * Simplified internal processing logic without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->