### PR TITLE
fix(federation): allow to join non-private or encrypted rooms based on settings

### DIFF
--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -90,6 +90,7 @@ export {
 	type BaseEventType,
 } from './utils/event-schemas';
 export { errCodes } from './utils/response-codes';
+export { NotAllowedError } from './services/invite.service';
 
 export { EventRepository } from './repositories/event.repository';
 export { RoomRepository } from './repositories/room.repository';
@@ -166,9 +167,6 @@ export type HomeserverEventSignatures = {
 	'homeserver.matrix.encryption': {
 		event_id: EventID;
 		event: PduForType<'m.room.encryption'>;
-		room_id: string;
-		sender: string;
-		origin_server_ts: number;
 	};
 	'homeserver.matrix.encrypted': {
 		event_id: EventID;

--- a/packages/federation-sdk/src/services/config.service.ts
+++ b/packages/federation-sdk/src/services/config.service.ts
@@ -31,6 +31,10 @@ export interface AppConfig {
 			downloadPerMinute: number;
 		};
 	};
+	invite: {
+		allowedEncryptedRooms: boolean;
+		allowedNonPrivateRooms: boolean;
+	};
 }
 
 export const AppConfigSchema = z.object({
@@ -68,6 +72,10 @@ export const AppConfigSchema = z.object({
 				.int()
 				.min(1, 'Download rate limit must be at least 1'),
 		}),
+	}),
+	invite: z.object({
+		allowedEncryptedRooms: z.boolean(),
+		allowedNonPrivateRooms: z.boolean(),
 	}),
 });
 
@@ -111,6 +119,10 @@ export class ConfigService {
 
 	getMediaConfig(): AppConfig['media'] {
 		return this.config.media;
+	}
+
+	getInviteConfig(): AppConfig['invite'] {
+		return this.config.invite;
 	}
 
 	async getSigningKey() {

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -845,7 +845,7 @@ export class RoomService {
 
 		// trying to join room from another server
 		const makeJoinResponse = await federationService.makeJoin(
-			residentServer as string,
+			residentServer,
 			roomId,
 			userId,
 			roomVersion, // NOTE: check the comment in the called method

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -312,9 +312,6 @@ export class StagingAreaService {
 				this.eventEmitterService.emit('homeserver.matrix.encryption', {
 					event_id: eventId,
 					event: event.event,
-					room_id: roomId,
-					sender: event.event.sender,
-					origin_server_ts: event.event.origin_server_ts,
 				});
 				break;
 			case event.event.type === 'm.room.encrypted':

--- a/packages/homeserver/src/controllers/federation/invite.controller.ts
+++ b/packages/homeserver/src/controllers/federation/invite.controller.ts
@@ -2,11 +2,17 @@ import { EventID, RoomID } from '@rocket.chat/federation-room';
 import {
 	EventAuthorizationService,
 	InviteService,
+	NotAllowedError,
 } from '@rocket.chat/federation-sdk';
 import { isAuthenticatedMiddleware } from '@rocket.chat/homeserver/middlewares/isAuthenticated';
 import { Elysia, t } from 'elysia';
 import { container } from 'tsyringe';
-import { ProcessInviteParamsDto, RoomVersionDto } from '../../dtos';
+import {
+	FederationErrorResponseDto,
+	ProcessInviteParamsDto,
+	ProcessInviteResponseDto,
+	RoomVersionDto,
+} from '../../dtos';
 
 export const invitePlugin = (app: Elysia) => {
 	const inviteService = container.resolve(InviteService);
@@ -14,18 +20,38 @@ export const invitePlugin = (app: Elysia) => {
 
 	return app.use(isAuthenticatedMiddleware(eventAuthService)).put(
 		'/_matrix/federation/v2/invite/:roomId/:eventId',
-		async ({ body, params: { roomId, eventId }, authenticatedServer }) => {
+		async ({ body, set, params: { roomId, eventId }, authenticatedServer }) => {
 			if (!authenticatedServer) {
 				throw new Error('Missing authenticated server from request');
 			}
 
-			return inviteService.processInvite(
-				body.event,
-				roomId as RoomID,
-				eventId as EventID,
-				body.room_version,
-				authenticatedServer,
-			);
+			try {
+				return await inviteService.processInvite(
+					body.event,
+					roomId as RoomID,
+					eventId as EventID,
+					body.room_version,
+					authenticatedServer,
+				);
+			} catch (error) {
+				if (error instanceof NotAllowedError) {
+					set.status = 403;
+					return {
+						errcode: 'M_FORBIDDEN',
+						error:
+							'This server does not allow joining this type of room based on federation settings.',
+					};
+				}
+
+				set.status = 500;
+				return {
+					errcode: 'M_UNKNOWN',
+					error:
+						error instanceof Error
+							? error.message
+							: 'Internal server error while processing request',
+				};
+			}
 		},
 		{
 			params: ProcessInviteParamsDto,
@@ -34,6 +60,11 @@ export const invitePlugin = (app: Elysia) => {
 				room_version: RoomVersionDto,
 				invite_room_state: t.Any(),
 			}),
+			response: {
+				200: ProcessInviteResponseDto,
+				403: FederationErrorResponseDto,
+				500: FederationErrorResponseDto,
+			},
 			detail: {
 				tags: ['Federation'],
 				summary: 'Process room invite',

--- a/packages/homeserver/src/dtos/federation/error.dto.ts
+++ b/packages/homeserver/src/dtos/federation/error.dto.ts
@@ -1,0 +1,15 @@
+import { type Static, t } from 'elysia';
+
+export const FederationErrorResponseDto = t.Object({
+	errcode: t.Enum({
+		M_UNRECOGNIZED: 'M_UNRECOGNIZED',
+		M_UNAUTHORIZED: 'M_UNAUTHORIZED',
+		M_FORBIDDEN: 'M_FORBIDDEN',
+		M_UNKNOWN: 'M_UNKNOWN',
+	}),
+	error: t.String(),
+});
+
+export type FederationErrorResponseDto = Static<
+	typeof FederationErrorResponseDto
+>;

--- a/packages/homeserver/src/dtos/index.ts
+++ b/packages/homeserver/src/dtos/index.ts
@@ -12,6 +12,7 @@ export * from './federation/state-ids.dto';
 export * from './federation/state.dto';
 export * from './federation/transactions.dto';
 export * from './federation/versions.dto';
+export * from './federation/error.dto';
 
 // Internal DTOs
 export * from './internal/invite.dto';

--- a/packages/homeserver/src/homeserver.module.ts
+++ b/packages/homeserver/src/homeserver.module.ts
@@ -88,6 +88,12 @@ export async function setup(options?: HomeserverSetupOptions) {
 				),
 			},
 		},
+		invite: {
+			allowedEncryptedRooms:
+				process.env.INVITE_ALLOWED_ENCRYPTED_ROOMS === 'true',
+			allowedNonPrivateRooms:
+				process.env.INVITE_ALLOWED_NON_PRIVATE_ROOMS === 'true',
+		},
 	});
 
 	const containerOptions: FederationContainerOptions = {

--- a/packages/room/src/types/v3-11.ts
+++ b/packages/room/src/types/v3-11.ts
@@ -714,7 +714,7 @@ const EventPduTypeRoomEncrypted = z.object({
 });
 
 const EventPduTypeRoomEncryption = z.object({
-	...PduNoContentTimelineEventSchema,
+	...PduNoContentEmptyStateKeyStateEventSchema,
 	type: z.literal('m.room.encryption'),
 	content: PduEncryptionEventContentSchema,
 });
@@ -789,7 +789,6 @@ export function isTimelineEventType(type: PduType) {
 	return (
 		type === 'm.room.message' ||
 		type === 'm.room.encrypted' ||
-		type === 'm.room.encryption' ||
 		type === 'm.reaction' ||
 		type === 'm.room.redaction'
 	);


### PR DESCRIPTION
### Changes:
- **Makes the federation invite route return 403 when `shouldProcessInvite` fails validation.**
  - Introduces a `NotAllowedError` custom error.
  - Updates Elysia error responses for federated endpoints to use `FederationErrorResponseDto`.
- Adds support for the `m.room.encryption` Matrix event and enables propagation of the `homeserver.matrix.encryption` event.
- Adds settings for `allowedEncryptedRooms` and `allowedNonPrivateRooms` to control invite behavior.

Related to https://github.com/RocketChat/Rocket.Chat/pull/37227.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable invite policy: enable/disable invites to encrypted and non‑private rooms via environment variables; runtime access to invite config exposed.
  * Federation event support: homeserver now emits encryption events for downstream notification/processing.
  * SDK error type: NotAllowedError exposed for blocked invite scenarios.
  * Room/encryption event schema: encryption event content added to public types.

* **Bug Fixes / API**
  * Invite route returns standardized federation-style 403/500 payloads for rejections and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->