### PR TITLE
chore: change pino's default timestamp format

### DIFF
--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -3,6 +3,7 @@ import pino from 'pino';
 const logger = pino({
 	name: 'homeserver',
 	level: process.env.LOG_LEVEL || 'info',
+	timestamp: pino.stdTimeFunctions.isoTime,
 	transport:
 		process.env.NODE_ENV === 'development'
 			? {


### PR DESCRIPTION
this will change the timestamp of the logs from this:
```
{"level":50,"time":1763152694596,"pid":1,"hostname":"10d51727d7f1","name":"homeserver","name":"FederationService","msg":"sendTransaction failed","err":{"type":"Error","message":"Federation request failed: 429 ","stack":"Error: Federation request failed: 429 \n    at z$.makeSignedRequest (/app/bundle/programs/server/npm/node_modules/@rocket.chat/packages/federation-sdk/src/services/federation-request.service.ts:118:14)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at z$.request (/app/bundle/programs/server/npm/node_modules/@rocket.chat/packages/federation-sdk/src/services/federation-request.service.ts:150:4)\n    at m.sendTransaction (/app/bundle/programs/server/npm/node_modules/@rocket.chat/packages/federation-sdk/src/services/federation.service.ts:112:11)\n    at m.sendEDUToServers (/app/bundle/programs/server/npm/node_modules/@rocket.chat/packages/federation-sdk/src/services/federation.service.ts:338:6)\n    at G0.sendTypingNotification (/app/bundle/programs/server/npm/node_modules/@rocket.chat/packages/federation-sdk/src/services/edu.service.ts:38:4)"}}
```

to this:
```
{"level":50,"time":"2025-11-14T20:37:06.553Z","pid":1,"hostname":"10d51727d7f1","name":"federation-matrix:message","err":{"type":"Error","message":"error-not-allowed","stack":"Error: error-not-allowed\n    at validateRoomMessagePermissionsAsync (app/authorization/server/functions/canSendMessage.ts:26:9)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at canSendMessageAsync (app/authorization/server/functions/canSendMessage.ts:58:2)\n    at executeSendMessage (app/lib/server/methods/sendMessage.ts:82:16)\n    at /app/bundle/programs/server/npm/node_modules/@rocket.chat/federation-matrix/src/events/message.ts:261:5"},"msg":"Error processing Matrix message:"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log entries now include timestamps in ISO format, improving ability to track when events occurred in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->