### PR TITLE
chore: rely on MongoDB client to parse db name instead of manual URL parsing

### DIFF
--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -144,7 +144,6 @@ export async function init({
 	emitter?: Emitter<HomeserverEventSignatures>;
 	dbConfig: {
 		uri: string;
-		name: string;
 		poolSize: number;
 	};
 }) {

--- a/packages/homeserver/src/homeserver.module.ts
+++ b/packages/homeserver/src/homeserver.module.ts
@@ -39,8 +39,7 @@ export async function setup() {
 
 	await init({
 		dbConfig: {
-			uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/matrix',
-			name: process.env.DATABASE_NAME || 'matrix',
+			uri: process.env.MONGO_URL || 'mongodb://localhost:27017/matrix',
 			poolSize: Number.parseInt(process.env.DATABASE_POOL_SIZE || '10', 10),
 		},
 	});


### PR DESCRIPTION
As per [FB-72](https://rocketchat.atlassian.net/browse/FB-72), when using MongoDB replica-set URLs (multiple hosts), the federation-matrix setup attempts to extract the database name by instantiating a URL object. Even though these MongoDB URLs are valid, the URL constructor does not support this format and throws `ERR_INVALID_URL`, preventing federation from starting.

This PR removes the manual URL parsing and `dbName` handling. We now read the database name directly from the MongoDB connection string using the MongoDB client parser. If the connection string does not contain a database name, we explicitly throw a clear error.

[FB-72]: https://rocketchat.atlassian.net/browse/FB-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified database configuration parameters by removing the explicit database name field; database selection is now managed internally.
  * Updated MongoDB connection to use the `MONGO_URL` environment variable instead of `MONGODB_URI`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->