### PR TITLE
fix: edu events being emitted even when not configured to

### DIFF
--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -318,6 +318,11 @@ export class EventService {
 		typingEDU: TypingEDU,
 		origin?: string,
 	): Promise<void> {
+		const config = this.configService.getConfig('edu');
+		if (!config.processTyping) {
+			return;
+		}
+
 		const { room_id, user_id, typing } = typingEDU.content;
 
 		if (!room_id || !user_id || typeof typing !== 'boolean') {
@@ -343,6 +348,11 @@ export class EventService {
 		presenceEDU: PresenceEDU,
 		origin?: string,
 	): Promise<void> {
+		const config = this.configService.getConfig('edu');
+		if (!config.processPresence) {
+			return;
+		}
+
 		const { push } = presenceEDU.content;
 
 		if (!push || !Array.isArray(push)) {


### PR DESCRIPTION
It doesn't make sense that `homeserver` is emitting the events `homeserver.matrix.presence` and `homeserver.matrix.typing` if the configuration says to not process them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Typing and presence detection can now be independently configured and disabled through system configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->