### PR TITLE
refactor: remove old emitter handling from EventEmitterService and cl…

### DIFF
--- a/packages/federation-sdk/src/index.ts
+++ b/packages/federation-sdk/src/index.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 
-import { Emitter } from '@rocket.chat/emitter';
 import type { EventStagingStore } from '@rocket.chat/federation-core';
 import type {
 	EventID,
@@ -140,10 +139,8 @@ export {
 } from '@rocket.chat/federation-room';
 
 export async function init({
-	emitter,
 	dbConfig,
 }: {
-	emitter?: Emitter<HomeserverEventSignatures>;
 	dbConfig: {
 		uri: string;
 		poolSize: number;
@@ -187,10 +184,6 @@ export async function init({
 			'rocketchat_federation_state_graphs',
 		),
 	});
-	const eventEmitterService = container.resolve(EventEmitterService);
-	if (emitter) {
-		eventEmitterService.setEmitter(emitter);
-	}
 	// this is required to initialize the listener and register the queue handler
 	container.resolve(StagingAreaListener);
 


### PR DESCRIPTION
closes https://rocketchat.atlassian.net/browse/FB-138
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified event system: all event subscription and emission now go through a single internal dispatcher; external emitter injection removed.
  * Initialization streamlined: SDK init no longer accepts or wires an external emitter.
  * Public event API simplified: subscribe/unsubscribe/emit operations now target only the internal event mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->