### PR TITLE
fix: include banned and invited servers in event destination set

### DIFF
--- a/packages/federation-sdk/src/services/state.service.spec.ts
+++ b/packages/federation-sdk/src/services/state.service.spec.ts
@@ -2262,7 +2262,7 @@ describe('StateService', async () => {
 			expect(servers.size).toBe(1);
 		});
 
-		it('should exclude servers with non-joined members', async () => {
+		it('should include servers with banned or invited members but exclude left', async () => {
 			const { roomCreateEvent } = await createRoom('public');
 
 			const creator = '@alice:example.com'; // Room creator with admin permissions
@@ -2284,9 +2284,9 @@ describe('StateService', async () => {
 
 			expect(servers.has('joined.com')).toBe(true);
 			expect(servers.has('left.com')).toBe(false);
-			expect(servers.has('banned.com')).toBe(false);
-			expect(servers.has('invited.com')).toBe(false);
-			expect(servers.size).toBe(2); // example.com (creator) + joined.com
+			expect(servers.has('banned.com')).toBe(true);
+			expect(servers.has('invited.com')).toBe(true);
+			expect(servers.size).toBe(4); // example.com (creator) + joined.com + banned.com + invited.com
 		});
 
 		it('should return creator server for room with only creator', async () => {

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -697,8 +697,10 @@ export class StateService {
 
 		const servers = new Set<string>();
 
+		const residentMemberships = new Set(['join', 'invite', 'ban']);
+
 		for (const event of state.values()) {
-			if (!event.isMembershipEvent() || event.getMembership() !== 'join') {
+			if (!event.isMembershipEvent() || !residentMemberships.has(event.getMembership() ?? '')) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary
- `getServerSetInRoom` now includes servers with `ban` or `invite` membership in addition to `join`
- Fixes broken state chain after ban+unban cycle that prevented re-invites in federated rooms

## Context
Closes #388

`getServerSetInRoom` only considered `join` membership, so after banning a user, their server stopped receiving events — including the unban event. This broke the state chain and made re-invites fail with "no previous state for event".

## Test plan
- [ ] Ban a user from a federated room (only user from their server)
- [ ] Unban the user — verify the leave event reaches the remote server
- [ ] Re-invite the user — verify the invite succeeds
- [ ] Verify `getServerSetInRoom` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server set retrieval to include servers hosting users with banned and invited membership statuses, in addition to joined users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->