### PR TITLE
chore: remove cycle dependency of EventService and StateService

### DIFF
--- a/packages/federation-sdk/src/services/event-notifier.service.ts
+++ b/packages/federation-sdk/src/services/event-notifier.service.ts
@@ -1,0 +1,212 @@
+import { createLogger } from '@rocket.chat/federation-core';
+import type { EventID, Pdu } from '@rocket.chat/federation-room';
+import { RoomState } from '@rocket.chat/federation-room';
+import { singleton } from 'tsyringe';
+
+import { EventEmitterService } from './event-emitter.service';
+import { StateService } from './state.service';
+
+@singleton()
+export class EventNotifierService {
+	private readonly logger = createLogger('EventNotifierService');
+
+	constructor(private readonly eventEmitterService: EventEmitterService, private readonly stateService: StateService) {}
+
+	async notify(event: { eventId: EventID; event: Pdu }) {
+		const {
+			eventId,
+			event: { room_id: roomId },
+		} = event;
+
+		this.logger.debug(`Notifying clients about event ${eventId}`);
+
+		switch (true) {
+			case event.event.type === 'm.room.create':
+				await this.eventEmitterService.emit('homeserver.matrix.room.create', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			case event.event.type === 'm.room.message':
+				await this.eventEmitterService.emit('homeserver.matrix.message', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			case event.event.type === 'm.room.encryption':
+				await this.eventEmitterService.emit('homeserver.matrix.encryption', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			case event.event.type === 'm.room.encrypted':
+				await this.eventEmitterService.emit('homeserver.matrix.encrypted', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			case event.event.type === 'm.reaction': {
+				await this.eventEmitterService.emit('homeserver.matrix.reaction', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.redaction': {
+				await this.eventEmitterService.emit('homeserver.matrix.redaction', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.member': {
+				await this.eventEmitterService.emit('homeserver.matrix.membership', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.name': {
+				await this.eventEmitterService.emit('homeserver.matrix.room.name', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.topic': {
+				await this.eventEmitterService.emit('homeserver.matrix.room.topic', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.server_acl': {
+				await this.eventEmitterService.emit('homeserver.matrix.room.server_acl', {
+					event_id: eventId,
+					event: event.event,
+				});
+				break;
+			}
+			case event.event.type === 'm.room.power_levels': {
+				await this.eventEmitterService.emit('homeserver.matrix.room.power_levels', {
+					event_id: eventId,
+					event: event.event,
+				});
+				const getRole = (powerLevel: number) => {
+					if (powerLevel === 100) {
+						return 'owner';
+					}
+					if (powerLevel === 50) {
+						return 'moderator';
+					}
+
+					return 'user';
+				};
+
+				const plEvent = await this.stateService.getEvent(eventId);
+				if (!plEvent) {
+					throw new Error(`Power level event ${eventId} not found in db`);
+				}
+
+				// at this point we potentially have the new power level event
+				const oldRoomState = new RoomState(await this.stateService.getStateBeforeEvent(plEvent));
+
+				const oldPowerLevels = oldRoomState.powerLevels?.users;
+
+				const changedUserPowers = event.event.content.users;
+
+				if (!changedUserPowers) {
+					this.logger.debug('No changed user powers, resetting all powers');
+					// everyone set to "user" except for the owner
+					const owner = oldRoomState.creator;
+					if (!oldPowerLevels) {
+						this.logger.debug('No current power levels, skipping');
+						break;
+					}
+
+					for await (const userId of Object.keys(oldPowerLevels)) {
+						if (userId === owner) {
+							continue;
+						}
+
+						this.logger.debug(`Resetting power level for ${userId} to user`);
+
+						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
+							sender_id: event.event.sender,
+							user_id: userId,
+							room_id: roomId,
+							role: 'user', // since new power level reset all powers
+						});
+					}
+				} else {
+					this.logger.debug('Changed user powers, emitting events');
+					if (!oldPowerLevels) {
+						this.logger.debug('No current power levels, setting new ones');
+						// no existing, set the new ones
+						for await (const [userId, power] of Object.entries(changedUserPowers)) {
+							this.logger.debug(`Setting power level for ${userId} to ${power}`);
+							await this.eventEmitterService.emit('homeserver.matrix.room.role', {
+								sender_id: event.event.sender,
+								user_id: userId,
+								room_id: roomId,
+								role: getRole(power),
+							});
+						}
+
+						break;
+					}
+					// need to know what changed
+					const usersInOldPowerLevelEvent = Object.keys(oldPowerLevels);
+					const usersInNewPowerLevelEvent = Object.keys(changedUserPowers);
+
+					const setOrUnsetPowerLevels = new Set(usersInNewPowerLevelEvent).difference(new Set(usersInOldPowerLevelEvent));
+
+					this.logger.debug(
+						{
+							difference: Array.from(setOrUnsetPowerLevels),
+						},
+						'Strong difference in power levels',
+					);
+
+					// for the difference only new power level content matters
+					for await (const userId of setOrUnsetPowerLevels) {
+						const newPowerLevel = changedUserPowers[userId]; // if unset, it's 0, if set, it's the power level
+						this.logger.debug(`Emitting event for ${userId} with new power level ${newPowerLevel ?? 0}`);
+						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
+							sender_id: event.event.sender,
+							user_id: userId,
+							room_id: roomId,
+							role: getRole(newPowerLevel),
+						});
+					}
+
+					this.logger.debug('Emitting events for changed user powers');
+
+					// now use the new content
+					for await (const [userId, power] of Object.entries(changedUserPowers)) {
+						if (
+							power === oldPowerLevels[userId] || // no change
+							setOrUnsetPowerLevels.has(userId) // already handled
+						) {
+							continue;
+						}
+
+						this.logger.debug(`Emitting event for ${userId} with power level ${power}`);
+
+						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
+							sender_id: event.event.sender,
+							user_id: userId,
+							room_id: roomId,
+							role: getRole(power),
+						});
+					}
+				}
+
+				break;
+			}
+			default:
+				this.logger.warn(`Unknown event type: ${event.event.type} for emitterService for now`);
+				break;
+		}
+	}
+}

--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -22,6 +22,7 @@ import {
 	type Pdu,
 	type PduForType,
 	type PduType,
+	type PersistentEventBase,
 	PersistentEventFactory,
 	RoomID,
 	RoomVersion,
@@ -813,7 +814,10 @@ export class EventService {
 		}
 	}
 
-	async notify(event: { eventId: EventID; event: Pdu }) {
-		return this.eventNotifierService.notify(event);
+	// single entry point for the staging-area hot path: authorize/persist the
+	// event through the state graph, then notify listeners
+	async authorizeAndPersist(event: PersistentEventBase): Promise<void> {
+		await this.stateService.handlePdu(event);
+		await this.eventNotifierService.notify(event);
 	}
 }

--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -24,7 +24,6 @@ import {
 	type PduType,
 	PersistentEventFactory,
 	RoomID,
-	RoomState,
 	RoomVersion,
 	getAuthChain,
 } from '@rocket.chat/federation-room';
@@ -33,6 +32,7 @@ import type { z } from 'zod';
 
 import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
+import { EventNotifierService } from './event-notifier.service';
 import { ServerService } from './server.service';
 import type { StateService } from './state.service';
 import { StagingAreaQueue } from '../queues/staging-area.queue';
@@ -63,6 +63,7 @@ export class EventService {
 		private readonly eventRepository: EventRepository,
 		@inject(delay(() => EventStagingRepository))
 		private readonly eventStagingRepository: EventStagingRepository,
+		private readonly eventNotifierService: EventNotifierService,
 	) {}
 
 	async getEventById<T extends PduType, P extends EventStore<PduForType<T>>>(eventId: EventID, type?: T): Promise<P | null> {
@@ -815,200 +816,6 @@ export class EventService {
 	}
 
 	async notify(event: { eventId: EventID; event: Pdu }) {
-		const {
-			eventId,
-			event: { room_id: roomId },
-		} = event;
-
-		this.logger.debug(`Notifying clients about event ${eventId}`);
-
-		switch (true) {
-			case event.event.type === 'm.room.create':
-				await this.eventEmitterService.emit('homeserver.matrix.room.create', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			case event.event.type === 'm.room.message':
-				await this.eventEmitterService.emit('homeserver.matrix.message', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			case event.event.type === 'm.room.encryption':
-				await this.eventEmitterService.emit('homeserver.matrix.encryption', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			case event.event.type === 'm.room.encrypted':
-				await this.eventEmitterService.emit('homeserver.matrix.encrypted', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			case event.event.type === 'm.reaction': {
-				await this.eventEmitterService.emit('homeserver.matrix.reaction', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.redaction': {
-				await this.eventEmitterService.emit('homeserver.matrix.redaction', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.member': {
-				await this.eventEmitterService.emit('homeserver.matrix.membership', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.name': {
-				await this.eventEmitterService.emit('homeserver.matrix.room.name', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.topic': {
-				await this.eventEmitterService.emit('homeserver.matrix.room.topic', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.server_acl': {
-				await this.eventEmitterService.emit('homeserver.matrix.room.server_acl', {
-					event_id: eventId,
-					event: event.event,
-				});
-				break;
-			}
-			case event.event.type === 'm.room.power_levels': {
-				await this.eventEmitterService.emit('homeserver.matrix.room.power_levels', {
-					event_id: eventId,
-					event: event.event,
-				});
-				const getRole = (powerLevel: number) => {
-					if (powerLevel === 100) {
-						return 'owner';
-					}
-					if (powerLevel === 50) {
-						return 'moderator';
-					}
-
-					return 'user';
-				};
-
-				const plEvent = await this.stateService.getEvent(eventId);
-				if (!plEvent) {
-					throw new Error(`Power level event ${eventId} not found in db`);
-				}
-
-				// at this point we potentially have the new power level event
-				const oldRoomState = new RoomState(await this.stateService.getStateBeforeEvent(plEvent));
-
-				const oldPowerLevels = oldRoomState.powerLevels?.users;
-
-				const changedUserPowers = event.event.content.users;
-
-				if (!changedUserPowers) {
-					this.logger.debug('No changed user powers, resetting all powers');
-					// everyone set to "user" except for the owner
-					const owner = oldRoomState.creator;
-					if (!oldPowerLevels) {
-						this.logger.debug('No current power levels, skipping');
-						break;
-					}
-
-					for await (const userId of Object.keys(oldPowerLevels)) {
-						if (userId === owner) {
-							continue;
-						}
-
-						this.logger.debug(`Resetting power level for ${userId} to user`);
-
-						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
-							sender_id: event.event.sender,
-							user_id: userId,
-							room_id: roomId,
-							role: 'user', // since new power level reset all powers
-						});
-					}
-				} else {
-					this.logger.debug('Changed user powers, emitting events');
-					if (!oldPowerLevels) {
-						this.logger.debug('No current power levels, setting new ones');
-						// no existing, set the new ones
-						for await (const [userId, power] of Object.entries(changedUserPowers)) {
-							this.logger.debug(`Setting power level for ${userId} to ${power}`);
-							await this.eventEmitterService.emit('homeserver.matrix.room.role', {
-								sender_id: event.event.sender,
-								user_id: userId,
-								room_id: roomId,
-								role: getRole(power),
-							});
-						}
-
-						break;
-					}
-					// need to know what changed
-					const usersInOldPowerLevelEvent = Object.keys(oldPowerLevels);
-					const usersInNewPowerLevelEvent = Object.keys(changedUserPowers);
-
-					const setOrUnsetPowerLevels = new Set(usersInNewPowerLevelEvent).difference(new Set(usersInOldPowerLevelEvent));
-
-					this.logger.debug(
-						{
-							difference: Array.from(setOrUnsetPowerLevels),
-						},
-						'Strong difference in power levels',
-					);
-
-					// for the difference only new power level content matters
-					for await (const userId of setOrUnsetPowerLevels) {
-						const newPowerLevel = changedUserPowers[userId]; // if unset, it's 0, if set, it's the power level
-						this.logger.debug(`Emitting event for ${userId} with new power level ${newPowerLevel ?? 0}`);
-						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
-							sender_id: event.event.sender,
-							user_id: userId,
-							room_id: roomId,
-							role: getRole(newPowerLevel),
-						});
-					}
-
-					this.logger.debug('Emitting events for changed user powers');
-
-					// now use the new content
-					for await (const [userId, power] of Object.entries(changedUserPowers)) {
-						if (
-							power === oldPowerLevels[userId] || // no change
-							setOrUnsetPowerLevels.has(userId) // already handled
-						) {
-							continue;
-						}
-
-						this.logger.debug(`Emitting event for ${userId} with power level ${power}`);
-
-						await this.eventEmitterService.emit('homeserver.matrix.room.role', {
-							sender_id: event.event.sender,
-							user_id: userId,
-							room_id: roomId,
-							role: getRole(power),
-						});
-					}
-				}
-
-				break;
-			}
-			default:
-				this.logger.warn(`Unknown event type: ${event.event.type} for emitterService for now`);
-				break;
-		}
+		return this.eventNotifierService.notify(event);
 	}
 }

--- a/packages/federation-sdk/src/services/event.service.ts
+++ b/packages/federation-sdk/src/services/event.service.ts
@@ -34,7 +34,7 @@ import { ConfigService } from './config.service';
 import { EventEmitterService } from './event-emitter.service';
 import { EventNotifierService } from './event-notifier.service';
 import { ServerService } from './server.service';
-import type { StateService } from './state.service';
+import { StateService } from './state.service';
 import { StagingAreaQueue } from '../queues/staging-area.queue';
 import { EventStagingRepository } from '../repositories/event-staging.repository';
 import { EventRepository } from '../repositories/event.repository';
@@ -54,8 +54,6 @@ export class EventService {
 	constructor(
 		private readonly configService: ConfigService,
 		private readonly stagingAreaQueue: StagingAreaQueue,
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		@inject(delay(() => require('./state.service').StateService))
 		private readonly stateService: StateService,
 		private readonly serverService: ServerService,
 		private readonly eventEmitterService: EventEmitterService,

--- a/packages/federation-sdk/src/services/invite.service.spec.ts
+++ b/packages/federation-sdk/src/services/invite.service.spec.ts
@@ -207,11 +207,9 @@ describe('InviteService', async () => {
 
 			// 3. Track notify calls
 			const notifyCalls: Array<{ eventId: string; type: string }> = [];
-			const notifySpy = spyOn((stateService as any).eventService, 'notify').mockImplementation(
-				async (event: { eventId: string; event: { type: string } }) => {
-					notifyCalls.push({ eventId: event.eventId, type: event.event.type });
-				},
-			);
+			const notifySpy = spyOn(notifierStub, 'notify').mockImplementation(async (event: { eventId: string; event: { type: string } }) => {
+				notifyCalls.push({ eventId: event.eventId, type: event.event.type });
+			});
 
 			// 4. Build state from send_join with a new join event
 			const existingState = await stateService.getLatestRoomState(roomId);
@@ -378,11 +376,9 @@ describe('InviteService', async () => {
 
 			// 2. Track notify calls
 			const notifyCalls: Array<{ eventId: string; type: string }> = [];
-			const notifySpy = spyOn((stateService as any).eventService, 'notify').mockImplementation(
-				async (event: { eventId: string; event: { type: string } }) => {
-					notifyCalls.push({ eventId: event.eventId, type: event.event.type });
-				},
-			);
+			const notifySpy = spyOn(notifierStub, 'notify').mockImplementation(async (event: { eventId: string; event: { type: string } }) => {
+				notifyCalls.push({ eventId: event.eventId, type: event.event.type });
+			});
 
 			// 3. Call processInitialState on a FRESH room (no prior state)
 			const statePdus = [creatorMemberEvent.event, powerLevelEvent.event, joinRuleEvent.event, inviteEvent.event];

--- a/packages/federation-sdk/src/services/invite.service.spec.ts
+++ b/packages/federation-sdk/src/services/invite.service.spec.ts
@@ -10,7 +10,7 @@ import type { ConfigService } from './config.service';
 import { DatabaseConnectionService } from './database-connection.service';
 import type { EventAuthorizationService } from './event-authorization.service';
 import type { EventEmitterService } from './event-emitter.service';
-import type { EventService } from './event.service';
+import type { EventNotifierService } from './event-notifier.service';
 import type { FederationValidationService } from './federation-validation.service';
 import type { FederationService } from './federation.service';
 import { InviteService } from './invite.service';
@@ -64,9 +64,11 @@ describe('InviteService', async () => {
 	const eventRepository = new EventRepository(eventCollection);
 	const stateGraphRepository = new StateGraphRepository(stateGraphCollection);
 
-	const stateService = new StateService(stateGraphRepository, eventRepository, configServiceInstance, {
+	const stateService = new StateService(stateGraphRepository, eventRepository, configServiceInstance);
+
+	const notifierStub = {
 		notify: () => Promise.resolve(),
-	} as unknown as EventService);
+	} as unknown as EventNotifierService;
 
 	const emitterService = {
 		emit: () => Promise.resolve(),
@@ -235,7 +237,7 @@ describe('InviteService', async () => {
 			const authChain = [createPdu.event, creatorMemberPdu.event, powerLevelsPdu.event, joinRulesPdu.event, reInviteEvent.event];
 
 			// 5. Call processInitialState on the EXISTING room
-			await stateService.processInitialState(statePdus, authChain);
+			await stateService.processInitialState(statePdus, authChain, notifierStub);
 
 			// 6. Only the new join event should be notified — NOT the already-known events
 			// (create, power_levels, join_rules, creator membership, invite, leave, re-invite)
@@ -288,7 +290,7 @@ describe('InviteService', async () => {
 			const authChain = [createPdu.event, creatorMemberPdu.event, powerLevelsPdu.event, joinRulesPdu.event, reInviteEvent.event];
 
 			// 4. Call processInitialState on existing room
-			await stateService.processInitialState(statePdus, authChain);
+			await stateService.processInitialState(statePdus, authChain, notifierStub);
 
 			// 5. Verify the join event is now stored in the DB
 			const storedJoinEvent = await eventRepository.findById(rejoinEvent.eventId);
@@ -386,7 +388,7 @@ describe('InviteService', async () => {
 			const statePdus = [creatorMemberEvent.event, powerLevelEvent.event, joinRuleEvent.event, inviteEvent.event];
 			const authChain = [roomCreateEvent.event, creatorMemberEvent.event, powerLevelEvent.event, joinRuleEvent.event];
 
-			await stateService.processInitialState(statePdus, authChain);
+			await stateService.processInitialState(statePdus, authChain, notifierStub);
 
 			// 4. ALL events should be notified, including m.room.create
 			const notifiedTypes = notifyCalls.map((c) => c.type);

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -32,6 +32,7 @@ import { DirectoryService } from './directory.service';
 import { EventAuthorizationService } from './event-authorization.service';
 import { EventEmitterService } from './event-emitter.service';
 import { EventFetcherService } from './event-fetcher.service';
+import { EventNotifierService } from './event-notifier.service';
 import { EventService } from './event.service';
 import { FederationValidationService } from './federation-validation.service';
 import { FederationService } from './federation.service';
@@ -63,6 +64,7 @@ export class RoomService {
 		private readonly eventStagingRepository: EventStagingRepository,
 		private readonly federationValidationService: FederationValidationService,
 		private readonly directoryService: DirectoryService,
+		private readonly eventNotifierService: EventNotifierService,
 	) {}
 
 	private validatePowerLevelChange(
@@ -807,7 +809,7 @@ export class RoomService {
 			this.logger.info({ roomId }, 'room not found, processing initial state');
 		}
 
-		await stateService.processInitialState(state, authChain);
+		await stateService.processInitialState(state, authChain, this.eventNotifierService);
 
 		if (await stateService.isRoomStatePartial(roomId)) {
 			this.logger.info({ roomId }, 'received incomplete graph of state from send_join, completing state before processing join');

--- a/packages/federation-sdk/src/services/staging-area.service.ts
+++ b/packages/federation-sdk/src/services/staging-area.service.ts
@@ -102,12 +102,7 @@ export class StagingAreaService {
 				}
 
 				// eslint-disable-next-line no-await-in-loop
-				await this.stateService.handlePdu(await toEventBase(event.event));
-				// eslint-disable-next-line no-await-in-loop
-				await this.eventService.notify({
-					eventId: event._id,
-					event: event.event,
-				});
+				await this.eventService.authorizeAndPersist(await toEventBase(event.event));
 				// eslint-disable-next-line no-await-in-loop
 				await this.eventService.markEventAsUnstaged(event);
 

--- a/packages/federation-sdk/src/services/state.service.spec.ts
+++ b/packages/federation-sdk/src/services/state.service.spec.ts
@@ -17,7 +17,7 @@ import { type WithId } from 'mongodb';
 
 import { type ConfigService } from './config.service';
 import { DatabaseConnectionService } from './database-connection.service';
-import type { EventService } from './event.service';
+import type { EventNotifierService } from './event-notifier.service';
 import { StateService } from './state.service';
 import { EventRepository } from '../repositories/event.repository';
 import { StateGraphRepository } from '../repositories/state-graph.repository';
@@ -129,9 +129,11 @@ describe('StateService', async () => {
 	const stateGraphRepository = new StateGraphRepository(stateGraphCollection);
 
 	// TODO: use IStateService
-	stateService = new StateService(stateGraphRepository, eventRepository, configServiceInstance, {
+	stateService = new StateService(stateGraphRepository, eventRepository, configServiceInstance);
+
+	const notifierStub = {
 		notify: () => Promise.resolve(),
-	} as unknown as EventService);
+	} as unknown as EventNotifierService;
 
 	const createRoom = async (
 		joinRule: PduJoinRuleEventContent['join_rule'],
@@ -2121,6 +2123,7 @@ describe('StateService', async () => {
 				const stateId = await stateService.processInitialState(
 					events.map((e) => e.event),
 					authChain.map((e) => e.event),
+					notifierStub,
 				);
 
 				console.log(state.ourUserJoinEvent.eventId);
@@ -2138,6 +2141,7 @@ describe('StateService', async () => {
 				await stateService.processInitialState(
 					events.map((e) => e.event),
 					authChain.map((e) => e.event),
+					notifierStub,
 				);
 
 				expect(stateService.isRoomStatePartial(events[0].roomId)).resolves.toBeTrue();
@@ -2149,6 +2153,7 @@ describe('StateService', async () => {
 				await stateService.processInitialState(
 					Object.values(state).map((e) => e.event),
 					authChain.map((e) => e.event),
+					notifierStub,
 				);
 
 				expect(stateService.isRoomStatePartial(state.roomCreateEvent.roomId)).resolves.toBeTrue();

--- a/packages/federation-sdk/src/services/state.service.ts
+++ b/packages/federation-sdk/src/services/state.service.ts
@@ -25,7 +25,7 @@ import {
 import { delay, inject, singleton } from 'tsyringe';
 
 import { ConfigService } from './config.service';
-import type { EventService } from './event.service';
+import type { EventNotifierService } from './event-notifier.service';
 import { EventRepository } from '../repositories/event.repository';
 import { StateGraphRepository } from '../repositories/state-graph.repository';
 
@@ -79,9 +79,6 @@ export class StateService {
 		@inject(delay(() => EventRepository))
 		private readonly eventRepository: EventRepository,
 		private readonly configService: ConfigService,
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		@inject(delay(() => require('./event.service').EventService))
-		private readonly eventService: EventService,
 	) {}
 
 	// TODO: this is a very vague method, better would be to use exactly what needed,
@@ -353,7 +350,9 @@ export class StateService {
 
 	// saves a full/partial state
 	// returns the final state id
-	async processInitialState(pdus: Pdu[], authChain: Pdu[]) {
+	// notifier is a parameter (not a constructor dependency) because EventNotifierService
+	// depends on this service for power-level diffs — injecting it would recreate the cycle
+	async processInitialState(pdus: Pdu[], authChain: Pdu[], notifier: EventNotifierService) {
 		const create = authChain.find((pdu) => pdu.type === 'm.room.create');
 		if (create?.type !== 'm.room.create') {
 			throw new Error('No create event found in auth chain to save');
@@ -461,7 +460,7 @@ export class StateService {
 			await this.addToRoomGraph(event, previousStateId);
 
 			if (!knownEventIds.has(event.eventId)) {
-				await this.eventService.notify(event);
+				await notifier.notify(event);
 			}
 		}
 


### PR DESCRIPTION
Closes #385 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/homeserver/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event notifications for supported federation room events, including messages, membership changes, reactions, redactions, room settings, and encryption.
  * Added role and permission change notifications when room power levels are updated.

* **Improvements**
  * Streamlined event authorization, persistence, and notification into a unified flow.
  * Improved event handling during room joins and initial state processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->