### PR TITLE
fix: use actual room versions instead of `defaultRoomVersion` everywhere

### DIFF
--- a/packages/federation-sdk/src/sdk.ts
+++ b/packages/federation-sdk/src/sdk.ts
@@ -259,6 +259,10 @@ export class FederationSDK {
 		return this.stateService.getLatestRoomState(...args);
 	}
 
+	getRoomVersion(...args: Parameters<typeof this.stateService.getRoomVersion>) {
+		return this.stateService.getRoomVersion(...args);
+	}
+
 	handlePdu(...args: Parameters<typeof this.stateService.handlePdu>) {
 		return this.stateService.handlePdu(...args);
 	}

--- a/packages/federation-sdk/src/services/room.service.ts
+++ b/packages/federation-sdk/src/services/room.service.ts
@@ -440,6 +440,8 @@ export class RoomService {
 	async updateUserPowerLevel(roomId: RoomID, userId: UserID, powerLevel: number, senderId: UserID): Promise<string> {
 		logger.info(`Updating power level for user ${userId} in room ${roomId} to ${powerLevel} by ${senderId}`);
 
+		const roomVersion = await this.stateService.getRoomVersion(roomId);
+
 		const authEventIds = await this.eventService.getAuthEventIds('m.room.power_levels', { roomId, senderId });
 
 		const powerLevelsAuthResult = this.getEventByType(authEventIds, 'm.room.power_levels');
@@ -512,7 +514,7 @@ export class RoomService {
 				origin_server_ts: Date.now(),
 				sender: eventToSign.sender,
 			},
-			PersistentEventFactory.defaultRoomVersion,
+			roomVersion,
 		);
 
 		await this.stateService.handlePdu(event);
@@ -741,7 +743,7 @@ export class RoomService {
 					origin_server_ts: Date.now(),
 					sender: userId,
 				},
-				PersistentEventFactory.defaultRoomVersion,
+				createEvent.version,
 			);
 
 			await stateService.handlePdu(membershipEvent);
@@ -760,16 +762,23 @@ export class RoomService {
 			return membershipEvent.eventId;
 		}
 
-		// Resident server is remote, need to do join flow
-		const roomVersion = '10' as const;
+		// Resident server is remote, need to do join flow.
+		// If we already have local state for this room (re-join), hint our known
+		// version to the resident server instead of asking it to pick from the
+		// full supported list.
+		let knownRoomVersion: RoomVersion | undefined;
+		let isRejoin = false;
+		try {
+			knownRoomVersion = await stateService.getRoomVersion(roomId);
+			isRejoin = true;
+		} catch (error) {
+			if (!(error instanceof UnknownRoomError)) {
+				throw error;
+			}
+		}
 
 		// trying to join room from another server
-		const makeJoinResponse = await federationService.makeJoin(
-			residentServer,
-			roomId,
-			userId,
-			roomVersion, // NOTE: check the comment in the called method
-		);
+		const makeJoinResponse = await federationService.makeJoin(residentServer, roomId, userId, knownRoomVersion);
 
 		// after receiving the join event we need to populate with local user profile
 		const profile = await this.profilesService.queryProfile(userId);
@@ -799,13 +808,9 @@ export class RoomService {
 		// from send_join and calls notify() for each event, which is how Rocket.Chat learns about
 		// the join. Without this, events go through the staging area where they get stuck on
 		// missing prev_events and are eventually silently dropped after MAX_EVENT_RETRY.
-		try {
-			await stateService.getRoomVersion(roomId);
+		if (isRejoin) {
 			this.logger.info({ roomId }, 'state already exists, updating with new state from send_join (re-join)');
-		} catch (error) {
-			if (!(error instanceof UnknownRoomError)) {
-				throw error;
-			}
+		} else {
 			this.logger.info({ roomId }, 'room not found, processing initial state');
 		}
 
@@ -1123,6 +1128,7 @@ export class RoomService {
 		if (!room) {
 			throw new HttpException('Room not found', HttpStatus.NOT_FOUND);
 		}
+		const roomVersion = await this.stateService.getRoomVersion(roomId);
 		const isTombstoned = await this.isRoomTombstoned(roomId);
 		if (isTombstoned) {
 			logger.warn(`Attempted to delete an already tombstoned room: ${roomId}`);
@@ -1173,7 +1179,7 @@ export class RoomService {
 				signatures: {},
 				type: 'm.room.tombstone',
 			},
-			PersistentEventFactory.defaultRoomVersion,
+			roomVersion,
 		);
 
 		const _stateId = await this.stateService.handlePdu(event);

--- a/packages/homeserver/src/controllers/internal/external-federation-request.controller.ts
+++ b/packages/homeserver/src/controllers/internal/external-federation-request.controller.ts
@@ -61,7 +61,7 @@ export const internalRequestPlugin = (app: Elysia) => {
 				roomId: RoomID;
 				sender: UserID;
 			};
-			const version = (query.version as RoomVersion | undefined) || PersistentEventFactory.defaultRoomVersion;
+			const version = (query.version as RoomVersion | undefined) || (await federationSDK.getRoomVersion(roomId));
 			switch (eventType) {
 				case 'm.room.member': {
 					const event = await federationSDK.buildEvent<'m.room.member'>(
@@ -203,7 +203,7 @@ export const internalRequestPlugin = (app: Elysia) => {
 		'/internal/event/send',
 		async ({ body, query }) => {
 			const event = body as Pdu;
-			const version = (query.version as RoomVersion | undefined) || PersistentEventFactory.defaultRoomVersion;
+			const version = (query?.version as RoomVersion | undefined) || (await federationSDK.getRoomVersion(event.room_id));
 			if (!PersistentEventFactory.isSupportedRoomVersion(version)) {
 				throw new Error(`Room version ${version} is not supported`);
 			}
@@ -219,7 +219,7 @@ export const internalRequestPlugin = (app: Elysia) => {
 		},
 		{
 			body: t.Any(),
-			query: t.Object({ version: t.String({ default: '10' }) }),
+			query: t.Optional(t.Object({ version: t.Optional(t.String()) })),
 			detail: {
 				tags: ['Devtools'],
 				summary: 'Send an event',

--- a/packages/room/src/manager/factory.ts
+++ b/packages/room/src/manager/factory.ts
@@ -38,7 +38,7 @@ export class PersistentEventFactory {
 		'11',
 	];
 
-	static defaultRoomVersion = '10' as const; // same as synapse
+	static defaultRoomVersion = '11' as const; // same as synapse
 
 	static isSupportedRoomVersion(roomVersion: string): roomVersion is RoomVersion {
 		return PersistentEventFactory.supportedRoomVersions.includes(roomVersion);


### PR DESCRIPTION
`defaultRoomVersion` should only be used at creation of a room. Everywhere else, grab version from state or from create event whichever is closer.

From claude
```
Function names using defaultRoomVersion (non-test files):

newCreateEvent (packages/room/src/manager/factory.ts)
getRoomVersion (packages/federation-sdk/src/services/event.service.ts)
createRoomV2 (packages/federation-sdk/src/services/room.service.ts)
createDirectMessageRoom (packages/federation-sdk/src/services/room.service.ts)
```

`getRoomVersion` returns default if fails to get from state, i'd argue we allow it to return undefined instead. but not touching that code here.

Claude wrote this patch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/homeserver/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving a room’s negotiated room version through the federation SDK.
  * Federation requests can now automatically determine the target room version when it isn’t specified.

* **Bug Fixes**
  * Room events now consistently use each room’s resolved version, improving federation joins, power-level updates, and room retirements.
  * Improved handling and logging when rejoining rooms with existing local state.

* **Changes**
  * New rooms now default to room version 11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->